### PR TITLE
feat: design system, component catalog, CONTRIBUTING guide, and event bus fix

### DIFF
--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -113,9 +113,11 @@ export class OlSearchPage extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener('click', this._onDoc);
-    window.addEventListener('ol-search',        this._globalSearch);
-    window.addEventListener('ol-filter-change', this._globalFilterChange);
-    window.addEventListener('ol-chip-remove',   this._globalChipRemove);
+    // Events from ol-search-bar are bubbles+composed — they reach this host naturally.
+    // Using this (not window) prevents accidental coupling with other page scripts.
+    this.addEventListener('ol-search',        this._globalSearch);
+    this.addEventListener('ol-filter-change', this._globalFilterChange);
+    this.addEventListener('ol-chip-remove',   this._globalChipRemove);
     const q = new URLSearchParams(location.search).get('q');
     if (q) { this._lastQ = q; this._runSearch(1); }
   }
@@ -137,9 +139,9 @@ export class OlSearchPage extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener('click', this._onDoc);
-    window.removeEventListener('ol-search',        this._globalSearch);
-    window.removeEventListener('ol-filter-change', this._globalFilterChange);
-    window.removeEventListener('ol-chip-remove',   this._globalChipRemove);
+    this.removeEventListener('ol-search',        this._globalSearch);
+    this.removeEventListener('ol-filter-change', this._globalFilterChange);
+    this.removeEventListener('ol-chip-remove',   this._globalChipRemove);
   }
 
   updated(changed) {


### PR DESCRIPTION
## Summary

- **Design system**: tokens.css extended with missing `fiction` and `subject` chip colors; all new components should use CSS custom properties from this file rather than raw HSL values
- **Component catalog** (`/catalog.html`): living preview page at `http://localhost:8090/catalog.html` showing tokens, `ol-search-bar` (both modes), `ol-book-card`, `ol-search-hint`, and shell composition; new components must add a section to `ol-catalog.js`
- **CONTRIBUTING.md**: human contributor guide covering three-layer architecture (design system → components → compositions), component contract checklist, testing philosophy, commit format, and PR process
- **Event bus fix**: replaced `window.addEventListener` in `ol-search-page` with `this.addEventListener` — events from `ol-search-bar` are `bubbles+composed` and reach the host naturally, removing accidental coupling risk on openlibrary.org
- **ARIA fixes** in `ol-search-bar`: `aria-controls`, `aria-activedescendant`, `aria-expanded` on facet buttons, `aria-live` on empty/hint states, focus return to facet button on dropdown close
- **ESLint**: added `AbortController` and `Promise` to browser globals

## Three-Layer Architecture

```
Design System  frontend/src/styles/tokens.css       — colors, spacing, type
Components     frontend/src/components/              — self-contained Lit components
Compositions   frontend/index.html + catalog.html    — OL shell and component preview
```

## Component Contract (new rule)

Every new component must: use design tokens, have a JSDoc block, a README.md entry, a catalog preview section in `ol-catalog.js`, and Vitest tests for any extractable pure logic.

## Test plan

- [x] `npm test` — 59/59 passing
- [x] `npm run lint` — clean
- [ ] Manual: visit `/catalog.html` in dev, verify all component sections render
- [ ] Manual: verify `ol-search-page` still receives search events in the OL composition
- [ ] Manual: confirm keyboard nav and screen reader ARIA on `ol-search-bar`