### PR TITLE
fix: show edition title in autocomplete suggestions

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -669,7 +669,7 @@ export class OlSearchBar extends LitElement {
                             ? html`<img class="ac-cover" src=${cover} alt="" loading="lazy">`
                             : html`<div class="ac-blank">📖</div>`}
                           <div class="ac-body">
-                            <div class="ac-title">${w.title}</div>
+                            <div class="ac-title">${ed?.title ?? w.title}</div>
                             <div class="ac-author">${(w.author_name ?? []).slice(0,2).join(', ')}</div>
                             ${w.first_publish_year ? html`<div class="ac-year">${w.first_publish_year}</div>` : ''}
                           </div>


### PR DESCRIPTION
## Summary

- In the autocomplete result rendering inside `ol-search-bar.js`, the title was always taken from the work (`w.title`) even when a best edition (`ed`) was already computed and may carry its own translated or edition-specific title.
- Changed `${w.title}` to `${ed?.title ?? w.title}` so the edition title takes precedence when available, falling back to the work title otherwise.
- Brings autocomplete into parity with `ol-book-card.js`, which already uses `const title = ed?.title ?? w.title`.

Closes #2