### PR TITLE
fix: include publicly readable books in readable-only filter

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -80,7 +80,7 @@ async def search(
     # We add an explicit OR to q_parts so both tiers appear in results, and keep the
     # ebook_access param (set to borrowable) to trigger block-join inner-hits.
     if availability == "readable":
-        q_parts.append('(ebook_access:borrowable OR ebook_access:public)')
+        q_parts.append('(ebook_access:[borrowable TO public])')
         params["q"] = " ".join(q_parts)  # refresh after appending ebook_access filter
         params["ebook_access"] = "borrowable"  # trigger block-join inner-hits
     elif availability == "open":

--- a/backend/main.py
+++ b/backend/main.py
@@ -76,9 +76,13 @@ async def search(
 
     # Availability: the 'ebook_access' URL param (not embedded in q) is what triggers
     # OL's Solr block-join inner-hits so editions.docs gets populated in the response.
-    # 'readable' maps to borrowable (covers IA lending library, the vast majority of cases).
+    # 'readable' includes both IA lending (borrowable) and openly readable (public) books.
+    # We add an explicit OR to q_parts so both tiers appear in results, and keep the
+    # ebook_access param (set to borrowable) to trigger block-join inner-hits.
     if availability == "readable":
-        params["ebook_access"] = "borrowable"
+        q_parts.append('(ebook_access:borrowable OR ebook_access:public)')
+        params["q"] = " ".join(q_parts)  # refresh after appending ebook_access filter
+        params["ebook_access"] = "borrowable"  # trigger block-join inner-hits
     elif availability == "open":
         params["ebook_access"] = "public"  # OL enum: 'public', not 'open'
     elif availability in ("borrowable", "printdisabled"):


### PR DESCRIPTION
## Summary

- The `readable` availability filter was only passing `ebook_access=borrowable` to OL's Solr, which excluded openly readable (`ebook_access=public`) books from results
- Fix adds an explicit OR filter to `q_parts` — `(ebook_access:borrowable OR ebook_access:public)` — so both IA lending and openly readable books appear
- The `ebook_access=borrowable` param is kept to continue triggering OL's Solr block-join inner-hits so `editions.docs` is populated in responses
- `params["q"]` is refreshed after appending the OR filter, since the params dict is built before availability is processed

Closes #7

## Test plan

- [ ] Search with "Readable only" filter selected — verify both borrowable (IA lending) and publicly readable books appear in results
- [ ] Search with a keyword (e.g. "python") + "Readable only" filter — confirm both access tiers are represented
- [ ] Filter-only browse (empty search query) with "Readable only" — confirm valid results are returned (the `q_parts` OR filter serves as the query anchor, so the empty-q fallback is not reached)
- [ ] "Open access" filter still works correctly (unchanged code path)
- [ ] "Borrowable" and "Print disabled" filters still work correctly (unchanged code paths)