### PR TITLE
fix: dismiss all panels in one outside click

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -84,6 +84,7 @@ export class OlSearchBar extends LitElement {
       if (!e.composedPath().includes(this)) {
         this._openFacet = null;
         this._open = false;
+        this._acFocusIdx = -1;
       }
     };
   }

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -82,11 +82,8 @@ export class OlSearchBar extends LitElement {
 
     this._onDoc = e => {
       if (!e.composedPath().includes(this)) {
-        if (this._openFacet !== null) {
-          this._openFacet = null;
-        } else {
-          this._open = false;
-        }
+        this._openFacet = null;
+        this._open = false;
       }
     };
   }


### PR DESCRIPTION
## Summary

- Fixes the two-click-to-close bug where clicking outside the component when a facet dropdown was open would only close the dropdown, leaving the main panel visible and requiring a second outside click
- Simplifies `_onDoc` to unconditionally set both `_openFacet = null` and `_open = false` on any click outside the component's shadow DOM
- No behavioral change for clicks inside the component (composedPath still includes the host element), facet button toggling (stopPropagation still prevents _onDoc from firing), or Escape key handling (unchanged in `_onKeyDown`)

## Test plan

- [ ] Open the search bar panel in droppable/header mode
- [ ] Click a facet button to open a facet dropdown
- [ ] Click anywhere outside the component — both the dropdown and panel should close in a single click
- [ ] Confirm clicking inside the panel (chips area, facet bar, autocomplete rows) does not close the dropdown
- [ ] Confirm Escape key still closes everything at once
- [ ] `npm test && npm run lint` pass (verified locally: 59 tests pass, lint clean)

Closes #3