### PR TITLE
style: larger facet caret and sort icon on sort button

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -538,7 +538,7 @@ export class OlSearchBar extends LitElement {
         <button class="pf-btn ${this._isFacetActive(name) ? 'active' : ''}"
                 aria-expanded=${this._openFacet === name ? 'true' : 'false'}
                 @click=${e => this._toggleFacet(name, e)}>
-          ${name === 'sort' ? html`<span class="pf-sort-icon" aria-hidden="true">⇅</span>` : ''}${this._facetLabel(name)}<span class="pf-caret">▾</span>
+          ${name === 'sort' ? html`<span class="pf-sort-icon" aria-hidden="true">⇅</span>` : ''}${this._facetLabel(name)}<span class="pf-caret" aria-hidden="true">▾</span>
         </button>
         ${this._openFacet === name ? html`
           <ol-facet-drop

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -429,7 +429,8 @@ export class OlSearchBar extends LitElement {
     }
     .pf-btn:hover  { background:hsl(0,0%,95%); color:hsl(202,96%,28%); }
     .pf-btn.active { color:hsl(202,96%,28%); font-weight:600; }
-    .pf-caret { font-size:8px; opacity:.5; flex-shrink:0; }
+    .pf-caret { font-size:10px; opacity:.5; flex-shrink:0; }
+    .pf-sort-icon { font-size:11px; opacity:.7; flex-shrink:0; }
 
     /* Clear input button */
     .clear-btn {
@@ -537,7 +538,7 @@ export class OlSearchBar extends LitElement {
         <button class="pf-btn ${this._isFacetActive(name) ? 'active' : ''}"
                 aria-expanded=${this._openFacet === name ? 'true' : 'false'}
                 @click=${e => this._toggleFacet(name, e)}>
-          ${this._facetLabel(name)}<span class="pf-caret">▾</span>
+          ${name === 'sort' ? html`<span class="pf-sort-icon" aria-hidden="true">⇅</span>` : ''}${this._facetLabel(name)}<span class="pf-caret">▾</span>
         </button>
         ${this._openFacet === name ? html`
           <ol-facet-drop


### PR DESCRIPTION
## Summary

- Increases `.pf-caret` `font-size` from `8px` to `10px` so the dropdown indicator is more legible
- Adds a `⇅` sort icon (with `aria-hidden="true"`) before the label on the sort facet button, giving it a clear visual affordance distinct from the other facet buttons

Closes #8

## Test plan

- [ ] Open the search bar in droppable mode (`showFacets`) and verify the caret on all facet buttons is slightly larger and easier to read
- [ ] Confirm the sort button shows `⇅ Relevance ▾` (or whichever sort is active)
- [ ] Confirm no icon appears on other facet buttons (Availability, Language, Genre, Subject, Author)
- [ ] Verify `npm test && npm run lint` pass cleanly