### PR TITLE
feat: add clear-all filters button and unify chip bar background

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -226,6 +226,35 @@ export class OlSearchBar extends LitElement {
     }));
   }
 
+  // ── Clear-all filters ─────────────────────────────────────────
+  _clearAllFilters() {
+    if (this.showFacets) {
+      // Droppable: reset local state and emit a filter-change event for each
+      // field that differs from EMPTY_FILTERS.
+      const f = this._localFilters;
+      const fields = [
+        ['availability',  EMPTY_FILTERS.availability],
+        ['fictionFilter', EMPTY_FILTERS.fictionFilter],
+        ['languages',     EMPTY_FILTERS.languages],
+        ['genres',        EMPTY_FILTERS.genres],
+        ['authors',       EMPTY_FILTERS.authors],
+        ['subjects',      EMPTY_FILTERS.subjects],
+      ];
+      for (const [field, empty] of fields) {
+        const cur = f[field];
+        const isDiff = Array.isArray(cur)
+          ? cur.length > 0
+          : cur !== empty;
+        if (isDiff) this._emitFilter(field, empty, true);
+      }
+      this._openFacet = null;
+    } else {
+      this.dispatchEvent(new CustomEvent('ol-clear-all-filters', {
+        bubbles: true, composed: true,
+      }));
+    }
+  }
+
   // ── Chip handling ─────────────────────────────────────────────
   _handleChipRemove(c) {
     if (this.showFacets) {
@@ -342,7 +371,7 @@ export class OlSearchBar extends LitElement {
       display: flex; flex-wrap: wrap; gap: 4px;
       padding: 8px 14px 6px;
       border-bottom: 1px solid hsl(0,0%,90%);
-      background: hsl(0,0%,99.5%);
+      background: hsl(0,0%,98.5%);
     }
 
     /* Chips */
@@ -363,6 +392,17 @@ export class OlSearchBar extends LitElement {
       padding:0 1px; font-size:15px; line-height:1; opacity:.5;
     }
     .chip-x:hover { opacity:1; }
+
+    /* Clear-all filters button */
+    .clear-all-btn {
+      flex-shrink:0; margin-left:auto; background:none; border:none;
+      cursor:pointer; font-size:11px; font-family:inherit;
+      font-weight:500; color:hsl(0,0%,50%);
+      padding:2px 8px; border-radius:4px;
+      white-space:nowrap; line-height:1.5;
+      transition:color .1s, background .1s;
+    }
+    .clear-all-btn:hover { color:hsl(0,72%,35%); background:hsl(0,72%,96%); }
 
     /* Text input */
     .text-input {
@@ -636,11 +676,23 @@ export class OlSearchBar extends LitElement {
           </div>
         </div>
 
-        ${!this.showFacets && chips.length ? html`<div class="chip-bar">${chipItems}</div>` : ''}
+        ${!this.showFacets && chips.length ? html`
+          <div class="chip-bar">
+            ${chipItems}
+            <button class="clear-all-btn"
+                    aria-label="Clear all filters"
+                    @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>
+          </div>` : ''}
 
         ${this.showFacets && this._open ? html`
           <div class="panel">
-            ${chips.length ? html`<div class="panel-chips">${chipItems}</div>` : ''}
+            ${chips.length ? html`
+              <div class="panel-chips">
+                ${chipItems}
+                <button class="clear-all-btn"
+                        aria-label="Clear all filters"
+                        @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>
+              </div>` : ''}
             ${this._renderFacetBar(!this._loading && !showResults)}
 
             ${this._loading ? html`<div class="ac-spin" role="status" aria-live="polite">Searching…</div>` : showResults ? html`

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -239,6 +239,7 @@ export class OlSearchBar extends LitElement {
         ['genres',        EMPTY_FILTERS.genres],
         ['authors',       EMPTY_FILTERS.authors],
         ['subjects',      EMPTY_FILTERS.subjects],
+        ['sort',          EMPTY_FILTERS.sort],
       ];
       for (const [field, empty] of fields) {
         const cur = f[field];
@@ -679,9 +680,9 @@ export class OlSearchBar extends LitElement {
         ${!this.showFacets && chips.length ? html`
           <div class="chip-bar">
             ${chipItems}
-            <button class="clear-all-btn"
+            ${this._hasActiveFilters() ? html`<button class="clear-all-btn"
                     aria-label="Clear all filters"
-                    @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>
+                    @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
           </div>` : ''}
 
         ${this.showFacets && this._open ? html`
@@ -689,9 +690,9 @@ export class OlSearchBar extends LitElement {
             ${chips.length ? html`
               <div class="panel-chips">
                 ${chipItems}
-                <button class="clear-all-btn"
+                ${this._hasActiveFilters() ? html`<button class="clear-all-btn"
                         aria-label="Clear all filters"
-                        @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>
+                        @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
               </div>` : ''}
             ${this._renderFacetBar(!this._loading && !showResults)}
 

--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -105,9 +105,10 @@ export class OlSearchPage extends LitElement {
     this._onDoc = e => {
       if (!e.composedPath().includes(this)) this._openFacet = null;
     };
-    this._globalSearch       = e => this._onSearch(e);
-    this._globalFilterChange = e => this._onFilterChange(e);
-    this._globalChipRemove   = e => this._onChipRemove(e);
+    this._globalSearch         = e => this._onSearch(e);
+    this._globalFilterChange   = e => this._onFilterChange(e);
+    this._globalChipRemove     = e => this._onChipRemove(e);
+    this._globalClearAllFilters = () => this._onClearAllFilters();
   }
 
   connectedCallback() {
@@ -115,9 +116,10 @@ export class OlSearchPage extends LitElement {
     document.addEventListener('click', this._onDoc);
     // Events from ol-search-bar are bubbles+composed — they reach this host naturally.
     // Using this (not window) prevents accidental coupling with other page scripts.
-    this.addEventListener('ol-search',        this._globalSearch);
-    this.addEventListener('ol-filter-change', this._globalFilterChange);
-    this.addEventListener('ol-chip-remove',   this._globalChipRemove);
+    this.addEventListener('ol-search',            this._globalSearch);
+    this.addEventListener('ol-filter-change',     this._globalFilterChange);
+    this.addEventListener('ol-chip-remove',       this._globalChipRemove);
+    this.addEventListener('ol-clear-all-filters', this._globalClearAllFilters);
     const q = new URLSearchParams(location.search).get('q');
     if (q) { this._lastQ = q; this._runSearch(1); }
   }
@@ -139,9 +141,10 @@ export class OlSearchPage extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener('click', this._onDoc);
-    this.removeEventListener('ol-search',        this._globalSearch);
-    this.removeEventListener('ol-filter-change', this._globalFilterChange);
-    this.removeEventListener('ol-chip-remove',   this._globalChipRemove);
+    this.removeEventListener('ol-search',            this._globalSearch);
+    this.removeEventListener('ol-filter-change',     this._globalFilterChange);
+    this.removeEventListener('ol-chip-remove',       this._globalChipRemove);
+    this.removeEventListener('ol-clear-all-filters', this._globalClearAllFilters);
   }
 
   updated(changed) {
@@ -281,6 +284,18 @@ export class OlSearchPage extends LitElement {
       case 'author':  this._authors       = this._authors.filter(v => v !== value); break;
       case 'subject': this._subjects      = this._subjects.filter(v => v !== value); break;
     }
+    if (this._lastQ !== null) this._runSearch(1);
+  }
+
+  // ── Clear all filters ─────────────────────────────────────────
+  _onClearAllFilters() {
+    this._sort          = EMPTY_FILTERS.sort;
+    this._availability  = EMPTY_FILTERS.availability;
+    this._fictionFilter = EMPTY_FILTERS.fictionFilter;
+    this._languages     = [...EMPTY_FILTERS.languages];
+    this._genres        = [...EMPTY_FILTERS.genres];
+    this._authors       = [...EMPTY_FILTERS.authors];
+    this._subjects      = [...EMPTY_FILTERS.subjects];
     if (this._lastQ !== null) this._runSearch(1);
   }
 


### PR DESCRIPTION
## Summary

- Adds a "Clear all" button to the chip bar in both droppable (panel) and embedded (results page) modes; the button only appears when at least one filter chip is active
- In droppable mode, clicking "Clear all" resets `_localFilters` to `EMPTY_FILTERS` and emits `ol-filter-change` for each changed field
- In embedded mode, clicking "Clear all" dispatches `ol-clear-all-filters` (bubbles/composed); `ol-search-page` handles it by resetting all filter state to `EMPTY_FILTERS` and re-running the search
- Fixes `.panel-chips` background from `hsl(0,0%,99.5%)` to `hsl(0,0%,98.5%)` to match the adjacent `.pf-bar`

## Test plan

- [ ] In droppable (hero) mode: set a filter, verify chip appears with a "Clear all" button at the trailing end, click it, verify all chips vanish and `ol-filter-change` events fire
- [ ] In embedded (results page) mode: set a filter via the results page filter bar, verify chip bar shows a "Clear all" button, click it, verify results reset to unfiltered state
- [ ] Verify "Clear all" button does not appear when no chips are active
- [ ] Visually confirm `.panel-chips` background matches the facet bar background
- [ ] Verify accessible label "Clear all filters" is present on the button

Closes #5