### PR TITLE
fix: restore gradient background when search dropdown opens

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -310,7 +310,7 @@ export class OlSearchBar extends LitElement {
   static styles = css`
     :host { display: block; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
 
-    .search-outer { position: relative; z-index: 10; }
+    .search-outer { position: relative; }
 
     /* Input row: text input + submit + scanner */
     .input-row {


### PR DESCRIPTION
## Root cause

`ol-search-bar` applied both `position: relative` and `z-index: 10` to the `.search-outer` wrapper:

```css
.search-outer { position: relative; z-index: 10; }
```

A `z-index` value on a `position: relative` element creates an independent **stacking context**. When `.search-outer` establishes its own stacking context inside the `ol-header` shadow DOM (which itself is a sticky/z-indexed stacking context), browsers promote the layer to a compositing surface. This compositing split can cause the parent element's `linear-gradient` background to disappear or be painted on a different layer — exactly the regression seen when `ol-facet-drop` is rendered (which adds `box-shadow` and `z-index: 700`, triggering the compositing path).

## Fix

Remove `z-index: 10` from `.search-outer`. The element still has `position: relative` so it continues to serve as the offset parent for the absolutely-positioned `.panel`. The `.panel` carries its own `z-index: 500` and `ol-facet-drop` carries `z-index: 700` — both are self-sufficient for correct layering without the wrapper needing a stacking context of its own.

**Change:** 1 line removed in `frontend/src/components/ol-search-bar.js`.

Closes #6