### PR TITLE
ci: add GitHub Actions workflow for lint, tests, and Python syntax check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  frontend:
+    name: Lint & Test (frontend)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+  backend:
+    name: Syntax check (backend)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Python syntax
+        run: python3 -m py_compile backend/main.py


### PR DESCRIPTION
Closes #16

## Summary

Adds a GitHub Actions CI workflow that runs automatically on every push to `main` and on every pull request.

## Jobs

**`frontend` — Lint & Test**
- Runs on `ubuntu-latest` with Node 20
- Uses `npm ci` for reproducible installs from `frontend/package-lock.json`
- npm cache keyed on `frontend/package-lock.json` so repeated runs are fast
- `npm run lint` — ESLint with the flat config in `frontend/`
- `npm test` — Vitest unit tests (`src/**/*.test.js`); Playwright E2E tests in `frontend/tests/` are intentionally excluded from this job

**`backend` — Syntax check**
- Runs `python3 -m py_compile backend/main.py` — lightweight but catches import/syntax errors early

## Why two separate jobs?

Lint/test failures and backend failures surface independently in the GitHub UI, so a backend syntax error doesn't hide a frontend lint failure and vice versa.