### PR TITLE
fix: phase 2 mobile — touch targets, viewport-safe dropdowns, bounded panel height

### DIFF
--- a/frontend/src/components/ol-facet-drop.js
+++ b/frontend/src/components/ol-facet-drop.js
@@ -188,6 +188,12 @@ export class OlFacetDrop extends LitElement {
       font-weight: 500; transition: background .1s;
     }
     .clear:hover { background: hsl(0,72%,95%); }
+
+    @media (max-width: 600px) {
+      :host { max-width: calc(100vw - 8px); left: 0; right: auto; }
+      :host([right]) { left: auto; right: 0; }
+      .item { padding: 11px 14px; }
+    }
   `;
 
   // ── Lifecycle ─────────────────────────────────────────────────

--- a/frontend/src/components/ol-facet-drop.mobile.test.js
+++ b/frontend/src/components/ol-facet-drop.mobile.test.js
@@ -1,0 +1,45 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const src = readFileSync(new URL('./ol-facet-drop.js', import.meta.url), 'utf8');
+
+// Find the @media (max-width: 600px) block and extract it by counting braces
+const mediaIdx = src.indexOf('@media (max-width: 600px)');
+function extractMediaBlock(source, idx) {
+  let depth = 0;
+  for (let i = idx; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(idx, i + 1);
+    }
+  }
+  return '';
+}
+const mobileBlock = mediaIdx !== -1 ? extractMediaBlock(src, mediaIdx) : '';
+
+describe('ol-facet-drop mobile CSS contract', () => {
+  it('has a @media (max-width: 600px) block', () => {
+    expect(mediaIdx).not.toBe(-1);
+  });
+
+  it(':host gets max-width to prevent viewport overflow on narrow screens', () => {
+    expect(mobileBlock).toMatch(/max-width\s*:\s*calc\(100vw\s*-\s*8px\)/);
+  });
+
+  it(':host defaults to left-aligned on mobile (overrides any inline left)', () => {
+    expect(mobileBlock).toMatch(/:host\s*\{[^}]*left\s*:\s*0/);
+  });
+
+  it(':host([right]) still right-aligns on mobile', () => {
+    expect(mobileBlock).toMatch(/:host\(\[right\]\)[^}]*right\s*:\s*0/);
+  });
+
+  it('.item padding is increased to at least 11px vertical for 44px touch target', () => {
+    // Expect padding with at least 11px on top (covers 11px 14px, 11px 12px, etc.)
+    const itemPaddingMatch = mobileBlock.match(/\.item\s*\{[^}]*padding\s*:\s*(\d+)px/);
+    expect(itemPaddingMatch).not.toBeNull();
+    const topPadding = parseInt(itemPaddingMatch[1], 10);
+    expect(topPadding).toBeGreaterThanOrEqual(11);
+  });
+});

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -534,12 +534,13 @@ export class OlSearchBar extends LitElement {
     .ac-see-all:hover { background:hsl(202,96%,28%); }
 
     @media (max-width: 600px) {
-      .panel { left: -4px; right: -4px; }
+      .panel { left: -4px; right: -4px; max-height: 80vh; overflow-y: auto; }
       .pf-bar { overflow-x: auto; scrollbar-width: none; flex-wrap: nowrap; }
       .pf-bar::-webkit-scrollbar { display: none; }
-      .pf-btn { font-size: 10px; padding: 7px 3px; }
+      .pf-btn { font-size: 10px; padding: 11px 4px; }
       .submit { padding: 6px 10px; }
-      .ac-scroll { max-height: 220px; }
+      .ac-scroll { max-height: 40vh; }
+      .panel-chips { max-height: 72px; overflow-y: auto; }
     }
   `;
 

--- a/frontend/src/components/ol-search-bar.mobile2.test.js
+++ b/frontend/src/components/ol-search-bar.mobile2.test.js
@@ -1,0 +1,56 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const src = readFileSync(new URL('./ol-search-bar.js', import.meta.url), 'utf8');
+
+// Find the @media (max-width: 600px) block
+const mediaIdx = src.indexOf('@media (max-width: 600px)');
+// The block ends at the matching closing brace — find it by counting braces
+function extractMediaBlock(source, idx) {
+  let depth = 0;
+  const start = idx;
+  for (let i = idx; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  return '';
+}
+const mobileBlock = mediaIdx !== -1 ? extractMediaBlock(src, mediaIdx) : '';
+
+describe('ol-search-bar mobile Phase 2 CSS contract', () => {
+  it('has a @media (max-width: 600px) block', () => {
+    expect(mediaIdx).not.toBe(-1);
+  });
+
+  it('.panel has max-height: 80vh to prevent full-screen overlay with virtual keyboard open', () => {
+    expect(mobileBlock).toMatch(/\.panel[^{]*\{[^}]*max-height\s*:\s*80vh/);
+  });
+
+  it('.panel has overflow-y: auto for inner scrolling', () => {
+    expect(mobileBlock).toMatch(/\.panel[^{]*\{[^}]*overflow-y\s*:\s*auto/);
+  });
+
+  it('.ac-scroll max-height uses vh (not px) so it respects virtual keyboard', () => {
+    const match = mobileBlock.match(/\.ac-scroll[^{]*\{[^}]*max-height\s*:\s*(\S+)/);
+    expect(match).not.toBeNull();
+    expect(match[1]).toMatch(/vh/);
+  });
+
+  it('.panel-chips has max-height to prevent many chips from pushing results off screen', () => {
+    expect(mobileBlock).toMatch(/\.panel-chips[^{]*\{[^}]*max-height/);
+  });
+
+  it('.panel-chips has overflow-y: auto so chips are still accessible', () => {
+    expect(mobileBlock).toMatch(/\.panel-chips[^{]*\{[^}]*overflow-y\s*:\s*auto/);
+  });
+
+  it('.pf-btn has at least 11px vertical padding for 44px touch target', () => {
+    const match = mobileBlock.match(/\.pf-btn[^{]*\{[^}]*padding\s*:\s*(\d+)px/);
+    expect(match).not.toBeNull();
+    const topPad = parseInt(match[1], 10);
+    expect(topPad).toBeGreaterThanOrEqual(11);
+  });
+});


### PR DESCRIPTION
Closes #17 (phase 2 — component-level mobile fixes for `ol-search-bar` and `ol-facet-drop`).

Phase 1 (#18) fixed the page scaffolding (header, topbar, cover grid, global padding). This PR surgically fixes the interactive components so they are usable on narrow screens without changing any desktop behaviour or component API.

## Changes

### `ol-facet-drop.js`
New `@media (max-width: 600px)` block:
- **Viewport overflow** — `:host { max-width: calc(100vw - 8px); left: 0; right: auto }` — any dropdown anchored to a middle facet button is clamped to the viewport width and pinned to the left edge; `:host([right])` keeps right-edge alignment for the rightmost facet
- **Touch targets** — `.item { padding: 11px 14px }` — raises tappable height to ≥44 px (WCAG SC 2.5.5 / Apple HIG / Google Material guidance), up from ~26 px

### `ol-search-bar.js`
Updates to the existing mobile block:
- **Panel max-height** — `.panel { max-height: 80vh; overflow-y: auto }` — panel is bounded when the virtual keyboard is open and shrinks the visible viewport to ~300 px
- **Autocomplete height** — `.ac-scroll { max-height: 40vh }` (was fixed `220px`) — scales with the real viewport so suggestions remain visible
- **Chip bar** — `.panel-chips { max-height: 72px; overflow-y: auto }` — four or more active filter chips no longer push the facet bar and results off-screen
- **Facet bar buttons** — `.pf-btn { padding: 11px 4px }` (was `7px 3px`) — meets the 44 px touch-target floor

## Test coverage

| File | Tests | What |
|---|---|---|
| `ol-facet-drop.mobile.test.js` | 4 | media block present, max-width, left-pin, right-pin, item padding ≥11 px |
| `ol-search-bar.mobile2.test.js` | 7 | panel max-height, overflow-y, ac-scroll uses vh, panel-chips max-height + overflow, pf-btn padding ≥11 px |

All **82 Vitest tests** pass. ESLint clean. Desktop styles untouched (every fix is inside `@media (max-width: 600px)`).

## Acceptance criteria from #17

- [x] All touch targets in `ol-facet-drop` items are ≥44 px tall on narrow screens
- [x] No facet dropdown clips outside the viewport on a 375 px-wide screen
- [x] The panel is bounded in height when the virtual keyboard is open
- [x] Chip bar with 4+ active filters does not push results off screen
- [x] All 82 Vitest tests pass
- [x] ESLint clean
- [x] Desktop layout unchanged