### PR TITLE
feat: full-screen mobile search overlay when ol-search-bar is activated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,17 @@ The PR body should state which test proves the fix, or link the screenshot inlin
 
 **Anti-pattern to avoid:** opening a bug-fix PR that only modifies source code with no test or screenshot. A fix with no proof is unverifiable and may silently regress.
 
+### Wait for Copilot review after opening a PR
+
+After opening a PR, **schedule a reminder to check for Copilot feedback in ~8 minutes** using `ScheduleWakeup`. Copilot typically posts its review within a few minutes of the PR being created; 8 minutes gives it enough time to finish without waiting too long.
+
+When the reminder fires:
+1. Fetch inline comments: `gh api repos/ArchiveLabs/openlibrary-components/pulls/<PR>/comments --jq '.[] | {id, node_id, line, path, body}'`
+2. Fetch the overview review: `gh pr view <PR> --repo ArchiveLabs/openlibrary-components --json reviews`
+3. Address every comment, push a fix commit, then reply and resolve each thread (see rule below).
+
+If there are no comments yet when the reminder fires, wait another few minutes before concluding there is no feedback.
+
 ### Responding to review comments (Copilot or human)
 
 After addressing review feedback and pushing the updated branch, **reply to each comment thread** you addressed and **resolve it**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,12 @@ The PR body should state which test proves the fix, or link the screenshot inlin
 
 After opening a PR, **schedule a reminder to check for Copilot feedback in ~8 minutes** using `ScheduleWakeup`. Copilot typically posts its review within a few minutes of the PR being created; 8 minutes gives it enough time to finish without waiting too long.
 
+`ScheduleWakeup` fires in the **same session** that opened the PR, so the prompt can be short — all project context, AGENTS.md rules, and the reply+resolve workflow are already in conversation history. The prompt only needs to identify the PR number and the action:
+
+```
+Check PR #<N> on ArchiveLabs/openlibrary-components for Copilot review feedback and address any comments per AGENTS.md.
+```
+
 When the reminder fires:
 1. Fetch inline comments: `gh api repos/ArchiveLabs/openlibrary-components/pulls/<PR>/comments --jq '.[] | {id, node_id, line, path, body}'`
 2. Fetch the overview review: `gh pr view <PR> --repo ArchiveLabs/openlibrary-components --json reviews`

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -742,7 +742,7 @@ export class OlSearchBar extends LitElement {
             ${this._mobileExpanded ? html`
               <div class="mob-back-bar">
                 <button class="mob-back-btn" aria-label="Close search"
-                        @click=${e => { e.stopPropagation(); this._mobileExpanded = false; this._open = false; this._openFacet = null; }}>
+                        @click=${e => { e.stopPropagation(); this._mobileExpanded = false; this._open = false; this._openFacet = null; this._acFocusIdx = -1; }}>
                   ← Back
                 </button>
               </div>` : nothing}

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -43,8 +43,9 @@ export class OlSearchBar extends LitElement {
     _subjectResults:  { state: true },
     _defaultAuthors:  { state: true },
     _defaultSubjects: { state: true },
-    _facetsLoading:   { state: true },
-    _acFocusIdx:      { state: true },  // keyboard-focused autocomplete result index
+    _facetsLoading:    { state: true },
+    _acFocusIdx:       { state: true },  // keyboard-focused autocomplete result index
+    _mobileExpanded:   { state: true },  // full-screen overlay active on narrow viewport
   };
 
   constructor() {
@@ -73,6 +74,7 @@ export class OlSearchBar extends LitElement {
     this._defaultSubjects = shufflePick(POPULAR_SUBJECTS, 6);
     this._facetsLoading   = false;
     this._acFocusIdx      = -1;
+    this._mobileExpanded  = false;
     this._authorTimer     = null;
     this._subjectTimer    = null;
     this._acAbort         = null;   // AbortController for in-flight autocomplete fetch
@@ -86,6 +88,7 @@ export class OlSearchBar extends LitElement {
         this._openFacet = null;
         this._open = false;
         this._acFocusIdx = -1;
+        this._mobileExpanded = false;
       } else if (this._openFacet !== null) {
         const inFacetDrop = path.some(el => el?.tagName === 'OL-FACET-DROP');
         const inFacetBtn  = path.some(el => el?.classList?.contains?.('pf-btn'));
@@ -123,6 +126,8 @@ export class OlSearchBar extends LitElement {
     if (changed.has('_openFacet') && changed.get('_openFacet') !== null && this._openFacet === null) {
       this._lastFacetBtn?.focus();
     }
+    // Sync full-screen overlay class on the host element.
+    this.classList.toggle('mobile-exp', this._mobileExpanded);
   }
 
   // ── Filter helpers ────────────────────────────────────────────
@@ -137,8 +142,12 @@ export class OlSearchBar extends LitElement {
 
   // ── Autocomplete ──────────────────────────────────────────────
   _onFocus() {
-    // Only open the panel in droppable mode.
-    if (this.showFacets) this._open = true;
+    if (this.showFacets) {
+      this._open = true;
+      if (window.matchMedia('(max-width: 600px)').matches) {
+        this._mobileExpanded = true;
+      }
+    }
     this._openFacet = null;
   }
 
@@ -198,7 +207,8 @@ export class OlSearchBar extends LitElement {
 
   _onKeyDown(e) {
     if (e.key === 'Escape') {
-      this._open = false; this._openFacet = null; this._acFocusIdx = -1; return;
+      this._open = false; this._openFacet = null; this._acFocusIdx = -1;
+      this._mobileExpanded = false; return;
     }
     // Arrow navigation through autocomplete results.
     if (this._open && this._suggestions.length > 0) {
@@ -223,6 +233,7 @@ export class OlSearchBar extends LitElement {
 
   _submit() {
     if (!this._q.trim() && !this._hasActiveFilters()) return;
+    this._mobileExpanded = false;
     this.dispatchEvent(new CustomEvent('ol-search', {
       detail: { q: this._q.trim(), filters: this._localFilters },
       bubbles: true, composed: true,
@@ -546,6 +557,43 @@ export class OlSearchBar extends LitElement {
       .submit { padding: 6px 10px; }
       .ac-scroll { max-height: 40vh; }
       .panel-chips { max-height: 72px; overflow-y: auto; }
+
+      /* ── Full-screen overlay (mobile-exp class toggled via JS) ── */
+      :host(.mobile-exp) {
+        position: fixed; inset: 0; z-index: 9000;
+        width: 100dvw; height: 100dvh;
+        display: flex; flex-direction: column;
+        background: white; overflow: hidden;
+      }
+      :host(.mobile-exp) .search-outer {
+        flex-shrink: 0; padding: 10px 12px;
+        border-bottom: 1.5px solid hsl(202,96%,37%);
+      }
+      :host(.mobile-exp) .search-outer.open .input-row {
+        border-bottom-left-radius: 8px;
+        border-bottom-right-radius: 8px;
+      }
+      :host(.mobile-exp) .panel {
+        position: static; flex: 1;
+        overflow-y: auto; max-height: none;
+        border: none; box-shadow: none; border-radius: 0;
+        border-top: none;
+      }
+      :host(.mobile-exp) .panel-chips { max-height: none; }
+      :host(.mobile-exp) .ac-scroll { max-height: none; }
+
+      /* Back button shown at top of the expanded panel */
+      .mob-back-bar {
+        padding: 8px 12px 4px;
+        border-bottom: 1px solid hsl(0,0%,92%);
+        background: hsl(0,0%,98.5%);
+      }
+      .mob-back-btn {
+        background: none; border: none; cursor: pointer;
+        font-size: 14px; font-family: inherit; color: hsl(202,96%,37%);
+        padding: 4px 0; font-weight: 500;
+      }
+      .mob-back-btn:hover { color: hsl(202,96%,28%); }
     }
   `;
 
@@ -691,6 +739,13 @@ export class OlSearchBar extends LitElement {
 
         ${this.showFacets && this._open ? html`
           <div class="panel">
+            ${this._mobileExpanded ? html`
+              <div class="mob-back-bar">
+                <button class="mob-back-btn" aria-label="Close search"
+                        @click=${e => { e.stopPropagation(); this._mobileExpanded = false; this._open = false; this._openFacet = null; }}>
+                  ← Back
+                </button>
+              </div>` : nothing}
             ${chips.length ? html`
               <div class="panel-chips">
                 ${chipItems}

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -1,0 +1,81 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const src = readFileSync(new URL('./ol-search-bar.js', import.meta.url), 'utf8');
+
+// Pull out just the @media (max-width: 600px) block by brace-counting
+function extractMediaBlock(source, startToken) {
+  const idx = source.indexOf(startToken);
+  if (idx === -1) return '';
+  let depth = 0;
+  for (let i = idx; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return source.slice(idx, i + 1);
+    }
+  }
+  return '';
+}
+
+const mobileBlock = extractMediaBlock(src, '@media (max-width: 600px)');
+
+describe('ol-search-bar mobile overlay CSS contract', () => {
+  it('has :host(.mobile-exp) rule inside the mobile media block', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)/);
+  });
+
+  it(':host(.mobile-exp) uses position: fixed for a true viewport overlay', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*position\s*:\s*fixed/);
+  });
+
+  it(':host(.mobile-exp) has z-index of at least 9000 to sit above all other content', () => {
+    const match = mobileBlock.match(/:host\(\.mobile-exp\)[^}]*z-index\s*:\s*(\d+)/);
+    expect(match).not.toBeNull();
+    expect(parseInt(match[1], 10)).toBeGreaterThanOrEqual(9000);
+  });
+
+  it(':host(.mobile-exp) covers the full dynamic viewport height with 100dvh', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*height\s*:\s*100dvh/);
+  });
+
+  it(':host(.mobile-exp) stretches to full width with 100dvw', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*width\s*:\s*100dvw/);
+  });
+
+  it(':host(.mobile-exp) .panel resets to static positioning (not absolute)', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
+  });
+
+  it(':host(.mobile-exp) .panel removes max-height constraint', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*max-height\s*:\s*none/);
+  });
+
+  it(':host(.mobile-exp) .ac-scroll removes max-height constraint', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.ac-scroll[^}]*max-height\s*:\s*none/);
+  });
+});
+
+describe('ol-search-bar mobile overlay JS contract', () => {
+  it('declares _mobileExpanded reactive state property', () => {
+    expect(src).toMatch(/_mobileExpanded\s*:\s*\{[^}]*state\s*:\s*true/);
+  });
+
+  it('initialises _mobileExpanded to false in constructor', () => {
+    expect(src).toMatch(/this\._mobileExpanded\s*=\s*false/);
+  });
+
+  it('sets _mobileExpanded = true in _onFocus when on mobile', () => {
+    expect(src).toMatch(/_mobileExpanded\s*=\s*true/);
+  });
+
+  it('clears _mobileExpanded in _onKeyDown Escape path', () => {
+    // Escape handler should reset the overlay
+    const escapeBlock = src.slice(src.indexOf("key === 'Escape'"), src.indexOf("key === 'Escape'") + 200);
+    expect(escapeBlock).toMatch(/_mobileExpanded\s*=\s*false/);
+  });
+
+  it('toggles mobile-exp class on :host via updated()', () => {
+    expect(src).toMatch(/classList\.toggle\s*\(\s*['"]mobile-exp['"]\s*,\s*this\._mobileExpanded\s*\)/);
+  });
+});

--- a/frontend/tests/mobile-overlay.spec.js
+++ b/frontend/tests/mobile-overlay.spec.js
@@ -1,0 +1,142 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForSearchBar(page) {
+  await page.waitForFunction(() => customElements.get('ol-search-bar') !== undefined);
+  await page.locator('ol-search-bar').waitFor({ state: 'attached' });
+}
+
+async function focusSearchInput(page) {
+  await page.evaluate(() => {
+    const sb = document.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('input')?.focus();
+    sb?.shadowRoot?.querySelector('input')?.dispatchEvent(
+      new MouseEvent('click', { bubbles: true, composed: true })
+    );
+  });
+}
+
+// ── Issue #23: full-screen mobile overlay ────────────────────────
+
+test.describe('mobile full-screen overlay (issue #23)', () => {
+  test('focusing search input on mobile adds mobile-exp class to host', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+
+    await focusSearchInput(page);
+
+    // Wait for the class to appear
+    await page.waitForFunction(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    const hasMobileExp = await page.evaluate(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
+    );
+    expect(hasMobileExp).toBe(true);
+
+    await page.screenshot({
+      path: 'tests/screenshots/mobile-overlay-open.png',
+      fullPage: false,
+    });
+  });
+
+  test('mobile-exp host has position:fixed covering the viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+    await focusSearchInput(page);
+
+    await page.waitForFunction(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    const { position, width, height } = await page.evaluate(() => {
+      const sb = document.querySelector('ol-search-bar');
+      const style = getComputedStyle(sb);
+      const box = sb.getBoundingClientRect();
+      return { position: style.position, width: box.width, height: box.height };
+    });
+
+    expect(position).toBe('fixed');
+    expect(width).toBeLessThanOrEqual(375);
+    expect(height).toBeGreaterThan(600);
+  });
+
+  test('back button dismisses the overlay', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+    await focusSearchInput(page);
+
+    await page.waitForFunction(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    // Click the back button inside the shadow DOM
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-search-bar');
+      const btn = sb?.shadowRoot?.querySelector('.mob-back-btn');
+      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+
+    await page.waitForFunction(() =>
+      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    const dismissed = await page.evaluate(() =>
+      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
+    );
+    expect(dismissed).toBe(true);
+
+    await page.screenshot({
+      path: 'tests/screenshots/mobile-overlay-dismissed.png',
+      fullPage: false,
+    });
+  });
+
+  test('Escape key dismisses the overlay', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+    await focusSearchInput(page);
+
+    await page.waitForFunction(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    await page.keyboard.press('Escape');
+
+    await page.waitForFunction(() =>
+      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
+      { timeout: 2000 }
+    );
+
+    const dismissed = await page.evaluate(() =>
+      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
+    );
+    expect(dismissed).toBe(true);
+  });
+});
+
+test.describe('desktop — no overlay regression', () => {
+  test('focusing search input on desktop does NOT add mobile-exp class', async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+    await focusSearchInput(page);
+
+    // Give it time to settle — the class should NOT appear
+    await page.waitForTimeout(300);
+
+    const hasMobileExp = await page.evaluate(() =>
+      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
+    );
+    expect(hasMobileExp).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #23

When a user taps the search input on a ≤600px viewport in droppable mode, `ol-search-bar` expands to a full-screen overlay that covers the entire visible viewport — hiding page content behind it — and reverts cleanly when dismissed.

## What changes

### JS (`ol-search-bar.js`)

| What | How |
|---|---|
| `_mobileExpanded` reactive state | Added to `static properties`; initialized `false` |
| Trigger | `_onFocus` calls `window.matchMedia('(max-width:600px)').matches` — only sets `_mobileExpanded = true` when on a narrow screen in droppable mode |
| Dismiss: back button | Rendered inside panel when `_mobileExpanded`; click sets both `_mobileExpanded = false` and `_open = false` |
| Dismiss: Escape key | `_onKeyDown` Escape branch also clears `_mobileExpanded` |
| Dismiss: submit | `_submit()` clears `_mobileExpanded` before firing `ol-search` |
| Dismiss: click-outside | `_onDoc` capture handler already resets `_open`; now also resets `_mobileExpanded` |
| Host class sync | `updated()` calls `this.classList.toggle('mobile-exp', this._mobileExpanded)` |

### CSS (`@media (max-width: 600px)` block)

```css
:host(.mobile-exp) {
  position: fixed; inset: 0; z-index: 9000;
  width: 100dvw; height: 100dvh;        /* dvh accounts for virtual keyboard */
  display: flex; flex-direction: column;
  background: white; overflow: hidden;
}
:host(.mobile-exp) .panel {
  position: static; flex: 1;
  overflow-y: auto; max-height: none;   /* overrides phase-2 80vh cap */
  border: none; box-shadow: none;
}
:host(.mobile-exp) .ac-scroll { max-height: none; }
```

Back button affordance (`.mob-back-bar` / `.mob-back-btn`) shown at the top of the panel.

### Desktop — zero change

`matchMedia` guard means the overlay is never activated on viewports wider than 600px. All new CSS is inside `@media (max-width: 600px)`.

## Proof

### Vitest CSS + JS contract (13 tests — `ol-search-bar.mobile-overlay.test.js`)
Tests that were **red before** this commit, **green after**:
- `:host(.mobile-exp)` rule exists in mobile media block
- `position: fixed`, `z-index ≥ 9000`, `height: 100dvh`, `width: 100dvw`
- `.panel` has `position: static` and `max-height: none`
- `.ac-scroll` has `max-height: none`
- `_mobileExpanded` declared, initialized, set to true, cleared on Escape
- `classList.toggle('mobile-exp', ...)` called in `updated()`

### Playwright E2E (5 tests — `tests/mobile-overlay.spec.js`)
| Test | Verifies |
|---|---|
| mobile-exp class added on focus | `classList.contains('mobile-exp')` is true after tapping input at 375px |
| fixed positioning covers viewport | `getComputedStyle` position = `fixed`; bounding height > 600px |
| back button dismisses | `mobile-exp` class removed after back button click |
| Escape key dismisses | `mobile-exp` class removed after `keyboard.press('Escape')` |
| desktop regression guard | `mobile-exp` class NOT added at 1440px viewport |

Screenshots: `tests/screenshots/mobile-overlay-open.png` and `mobile-overlay-dismissed.png`

All **95 Vitest tests** pass. ESLint clean.