### PR TITLE
feat: viewport-anchored panel overlay + mobile full-screen search (issue #23)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -24,6 +24,8 @@ export default [
         localStorage: 'readonly',
         AbortController: 'readonly',
         Promise: 'readonly',
+        requestAnimationFrame: 'readonly',
+        DOMException: 'readonly',
       },
     },
     rules: {

--- a/frontend/src/components/ol-facet-drop.js
+++ b/frontend/src/components/ol-facet-drop.js
@@ -1,4 +1,5 @@
 import { LitElement, html, css } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import {
   SORT_OPTIONS, AVAILABILITY_OPTIONS, LANGUAGE_OPTIONS, GENRE_OPTIONS, FICTION_OPTIONS,
   toggleArrayValue,
@@ -273,7 +274,7 @@ export class OlFacetDrop extends LitElement {
         ${unselVisible.length === 0
           ? html`<div class="empty">${this._langSearch ? 'No matches' : 'All selected'}</div>`
           : ''}
-        ${unselVisible.map(o => html`
+        ${repeat(unselVisible, o => o.value, o => html`
           <button class="item"
               @click=${() => this._change('languages', toggleArrayValue(selected, o.value), true)}>
             <input type="checkbox" .checked=${false} readonly> ${o.label}
@@ -325,7 +326,7 @@ export class OlFacetDrop extends LitElement {
         ${unselVisible.length === 0
           ? html`<div class="empty">${this._genreSearch ? 'No matches' : 'All selected'}</div>`
           : ''}
-        ${unselVisible.map(o => html`
+        ${repeat(unselVisible, o => o.value, o => html`
           <button class="item"
               @click=${() => this._change('genres', toggleArrayValue(selectedGenres, o.value), true)}>
             <input type="checkbox" .checked=${false} readonly> ${o.label}
@@ -377,7 +378,7 @@ export class OlFacetDrop extends LitElement {
           ? html`<div class="hint">Type to search authors</div>` : ''}
         ${searching && !this.facetsLoading && this.authorResults.length === 0
           ? html`<div class="empty">No authors found</div>` : ''}
-        ${!this.facetsLoading ? unselSugg.map(a => html`
+        ${!this.facetsLoading ? repeat(unselSugg, a => a.name, a => html`
           <button class="item"
               @click=${() => this._change('authors', toggleArrayValue(selectedAuthors, a.name), true)}>
             <input type="checkbox" .checked=${false} readonly>
@@ -430,7 +431,7 @@ export class OlFacetDrop extends LitElement {
           ? html`<div class="hint">Type to search subjects</div>` : ''}
         ${searching && !this.facetsLoading && this.subjectResults.length === 0
           ? html`<div class="empty">No subjects found</div>` : ''}
-        ${!this.facetsLoading ? unselSugg.map(s => html`
+        ${!this.facetsLoading ? repeat(unselSugg, s => s.name, s => html`
           <button class="item"
               @click=${() => this._change('subjects', toggleArrayValue(selectedSubjects, s.name), true)}>
             <input type="checkbox" .checked=${false} readonly>

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -730,15 +730,14 @@ export class OlSearchBar extends LitElement {
 
 
   // Order: avail → lang → genre → subject → author → sort → cog
+  // Dropdowns in the first half open left-aligned; those after the midpoint open
+  // right-aligned so they don't overflow the edge of the panel on narrow viewports.
   _renderFacetBar() {
+    const facets = ['avail', 'lang', 'genre', 'subject', 'author', 'sort'];
+    const mid    = Math.floor((facets.length - 1) / 2); // 2 for 6 facets
     return html`
       <div class="pf-bar">
-        ${this._renderFacetBtn('avail',  false, 'pf-wrap--first')}
-        ${this._renderFacetBtn('lang')}
-        ${this._renderFacetBtn('genre')}
-        ${this._renderFacetBtn('subject')}
-        ${this._renderFacetBtn('author')}
-        ${this._renderFacetBtn('sort', true)}
+        ${facets.map((name, i) => this._renderFacetBtn(name, i > mid, i === 0 ? 'pf-wrap--first' : ''))}
         <div class="pf-wrap pf-wrap--cog pf-wrap--last">
           <button class="pf-btn" title="Search help"
                   @click=${e => { e.stopPropagation(); this._howtoOpen = true; }}>⚙️</button>

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -782,7 +782,7 @@ export class OlSearchBar extends LitElement {
                    href="${this.siteBase}${linkKey}"
                    target="_blank" rel="noopener"
                    role="option"
-                   @click=${() => this._open = false}>
+                   @click=${() => { this._open = false; this._mobileExpanded = false; }}>
                   ${cover
                     ? html`<img class="ac-cover" src=${cover} alt="" loading="lazy">`
                     : html`<div class="ac-blank">📖</div>`}
@@ -806,7 +806,7 @@ export class OlSearchBar extends LitElement {
            target="_blank" rel="noopener"
            @click=${e => e.stopPropagation()}>+ Add Book</a>
         <button class="ac-see-all" @click=${() => {
-          this._open = false;
+          this._open = false; this._mobileExpanded = false;
           if (!q && !this._hasActiveFilters()) return;
           this.dispatchEvent(new CustomEvent('ol-search', {
             detail: { q, filters: this._localFilters }, bubbles: true, composed: true,
@@ -861,7 +861,6 @@ export class OlSearchBar extends LitElement {
     }
 
     // ── Droppable (header) mode: trigger button + fixed panel overlay ──
-    const showResults = q.length >= 2 || this._hasActiveFilters();
     return html`
       <div class="search-outer ${this._open ? 'open' : ''}" role="search">
 
@@ -870,7 +869,8 @@ export class OlSearchBar extends LitElement {
           <button class="trigger-btn"
                   @click=${this._onTriggerClick}
                   aria-expanded=${this._open ? 'true' : 'false'}
-                  aria-haspopup="dialog"
+                  aria-haspopup="true"
+                  aria-controls="search-panel"
                   aria-label="${this.placeholder}">
             <span class="${!this._q ? 'trigger-placeholder' : ''}">${this._q || this.placeholder}</span>
           </button>
@@ -891,7 +891,7 @@ export class OlSearchBar extends LitElement {
 
         <!-- Panel overlay (position:fixed via CSS vars set by _positionPanel) -->
         ${this._open ? html`
-          <div class="panel">
+          <div class="panel" id="search-panel" role="dialog" aria-modal=${this._mobileExpanded ? 'true' : 'false'} aria-label="${this.placeholder}">
             ${this._mobileExpanded ? html`
               <div class="mob-back-bar">
                 <button class="mob-back-btn" aria-label="Close search"

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -4,6 +4,8 @@ import {
   EMPTY_FILTERS, shufflePick, bestEdition,
   getSortLabel, buildChips,
 } from '../utils/filters.js';
+import { BREAKPOINTS } from '../utils/breakpoints.js';
+import { fetchAuthorSuggestions, fetchSubjectSuggestions } from '../utils/facets.js';
 import './ol-howto-modal.js';
 import './ol-facet-drop.js';
 
@@ -84,7 +86,7 @@ export class OlSearchBar extends LitElement {
 
     this._onWinResize = () => {
       if (!this._open) return;
-      const isMobile = window.matchMedia('(max-width: 600px)').matches;
+      const isMobile = window.matchMedia(`(max-width: ${BREAKPOINTS.mobile}px)`).matches;
       if (isMobile && !this._mobileExpanded) {
         this._mobileExpanded = true;           // shrunk into mobile — switch to full-screen overlay
       } else if (!isMobile && this._mobileExpanded) {
@@ -161,7 +163,7 @@ export class OlSearchBar extends LitElement {
     const rect = trigger.getBoundingClientRect();
     const vw   = window.innerWidth;
     this.style.setProperty('--ol-panel-top', `${rect.top}px`);
-    if (vw > 900) {
+    if (vw > BREAKPOINTS.wide) {
       const desired = Math.max(600, Math.min(860, rect.width));
       const panelW  = Math.min(desired, rect.right - 8);
       this.style.setProperty('--ol-panel-width', `${panelW}px`);
@@ -192,7 +194,7 @@ export class OlSearchBar extends LitElement {
   _onTriggerClick(e) {
     e.stopPropagation();
     this._open = true;
-    if (window.matchMedia('(max-width: 600px)').matches) {
+    if (window.matchMedia(`(max-width: ${BREAKPOINTS.mobile}px)`).matches) {
       this._mobileExpanded = true;
     }
     this._openFacet = null;
@@ -369,10 +371,9 @@ export class OlSearchBar extends LitElement {
     const { signal } = this._authorAbort;
     this._authorTimer = setTimeout(async () => {
       try {
-        const d = await (await fetch(`${this.apiBase}/api/authors/search?q=${encodeURIComponent(q.trim())}&limit=8`, { signal })).json();
-        this._authorResults = d.docs ?? [];
-      } catch (err) {
-        if (err.name !== 'AbortError') this._authorResults = [];
+        this._authorResults = await fetchAuthorSuggestions(q, { signal, apiBase: this.apiBase });
+      } catch {
+        this._authorResults = [];
       } finally {
         if (!signal.aborted) this._facetsLoading = false;
       }
@@ -389,10 +390,9 @@ export class OlSearchBar extends LitElement {
     const { signal } = this._subjectAbort;
     this._subjectTimer = setTimeout(async () => {
       try {
-        const d = await (await fetch(`${this.apiBase}/api/subjects/search?q=${encodeURIComponent(q.trim())}&limit=8`, { signal })).json();
-        this._subjectResults = d.docs ?? [];
-      } catch (err) {
-        if (err.name !== 'AbortError') this._subjectResults = [];
+        this._subjectResults = await fetchSubjectSuggestions(q, { signal, apiBase: this.apiBase });
+      } catch {
+        this._subjectResults = [];
       } finally {
         if (!signal.aborted) this._facetsLoading = false;
       }

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -83,7 +83,16 @@ export class OlSearchBar extends LitElement {
     this._lastFacetBtn    = null;   // button that opened the current facet dropdown (for focus return)
 
     this._onWinResize = () => {
-      if (this._open) { this._open = false; this._openFacet = null; }
+      if (!this._open) return;
+      const isMobile = window.matchMedia('(max-width: 600px)').matches;
+      if (isMobile && !this._mobileExpanded) {
+        this._mobileExpanded = true;           // shrunk into mobile — switch to full-screen overlay
+      } else if (!isMobile && this._mobileExpanded) {
+        this._mobileExpanded = false;          // grown out of mobile — switch to positioned panel
+        requestAnimationFrame(() => this._positionPanel());
+      } else if (!isMobile) {
+        requestAnimationFrame(() => this._positionPanel()); // desktop resize — reposition
+      }
     };
 
     this._onDoc = e => {
@@ -134,27 +143,37 @@ export class OlSearchBar extends LitElement {
     }
     // Sync full-screen overlay class on the host element.
     this.classList.toggle('mobile-exp', this._mobileExpanded);
-    // Anchor the panel to the trigger and focus the panel-input when it opens (desktop only).
-    if (changed.has('_open') && this._open && this.showFacets && !this._mobileExpanded) {
-      this._positionPanel();
+    // Anchor the panel to the trigger and focus the panel-input when it opens.
+    if (changed.has('_open') && this._open && this.showFacets) {
+      if (!this._mobileExpanded) this._positionPanel();
       requestAnimationFrame(() => this.shadowRoot?.querySelector('.panel-input')?.focus());
     }
   }
 
   // Set CSS custom properties on :host so the panel's position:fixed CSS vars resolve
-  // to the correct viewport-anchored coordinates. Right edge aligns with the trigger;
-  // panel extends leftward with a minimum width so facets never overflow.
+  // to the correct viewport-anchored coordinates.
+  // ≥900px: right-aligned with trigger, min 600px wide.
+  // 600–900px: horizontally centered, 85% viewport width.
   _positionPanel() {
     if (this._mobileExpanded) return;
     const trigger = this.shadowRoot?.querySelector('.input-row');
     if (!trigger) return;
-    const rect    = trigger.getBoundingClientRect();
-    const vw      = window.innerWidth;
-    const desired = Math.max(600, Math.min(860, rect.width));
-    const panelW  = Math.min(desired, rect.right - 8);
-    this.style.setProperty('--ol-panel-top',   `${rect.top}px`);
-    this.style.setProperty('--ol-panel-right', `${Math.max(0, vw - rect.right)}px`);
-    this.style.setProperty('--ol-panel-width', `${panelW}px`);
+    const rect = trigger.getBoundingClientRect();
+    const vw   = window.innerWidth;
+    this.style.setProperty('--ol-panel-top', `${rect.top}px`);
+    if (vw > 900) {
+      const desired = Math.max(600, Math.min(860, rect.width));
+      const panelW  = Math.min(desired, rect.right - 8);
+      this.style.setProperty('--ol-panel-width', `${panelW}px`);
+      this.style.setProperty('--ol-panel-right', `${Math.max(0, vw - rect.right)}px`);
+      this.style.setProperty('--ol-panel-left',  'auto');
+    } else {
+      const panelW = Math.max(600, Math.round(vw * 0.85));
+      const left   = Math.round((vw - panelW) / 2);
+      this.style.setProperty('--ol-panel-width', `${panelW}px`);
+      this.style.setProperty('--ol-panel-left',  `${left}px`);
+      this.style.setProperty('--ol-panel-right', 'auto');
+    }
   }
 
   // ── Filter helpers ────────────────────────────────────────────
@@ -484,14 +503,15 @@ export class OlSearchBar extends LitElement {
       flex:1; min-width:0; border:none; outline:none; cursor:pointer;
       background:transparent; font-size:14px; font-family:inherit;
       padding:2px 4px; text-align:left; color:hsl(0,0%,15%);
+      overflow:hidden; white-space:nowrap; text-overflow:ellipsis;
     }
     .trigger-placeholder { color:hsl(0,0%,52%); }
 
     /* Panel-input row: real search input that lives inside the panel overlay */
     .panel-input-row {
-      display:flex; align-items:center; gap:5px;
+      display:flex; align-items:center; min-width:0; gap:6px;
       padding:6px 8px; border-bottom:1px solid hsl(0,0%,90%);
-      background:white;
+      background:white; border-radius:6.5px 6.5px 0 0;
     }
 
     /* Panel (droppable mode only) — position driven by CSS custom props set in _positionPanel() */
@@ -500,7 +520,7 @@ export class OlSearchBar extends LitElement {
       top:var(--ol-panel-top, auto);
       right:var(--ol-panel-right, 0px);
       width:var(--ol-panel-width, 600px);
-      left:auto;
+      left:var(--ol-panel-left, auto);
       background:white;
       border:1.5px solid hsl(202,96%,37%);
       border-radius:8px;
@@ -513,7 +533,6 @@ export class OlSearchBar extends LitElement {
       display:flex; border-bottom:1px solid hsl(0,0%,90%);
       background:hsl(0,0%,98.5%);
     }
-    .pf-bar--round { border-radius: 0 0 9px 9px; }
     .pf-wrap { flex:1; position:relative; display:flex; }
     .pf-wrap + .pf-wrap { border-left:1px solid hsl(0,0%,90%); }
     .pf-wrap--cog { flex:0 0 38px; }
@@ -595,6 +614,54 @@ export class OlSearchBar extends LitElement {
     }
     .ac-see-all:hover { background:hsl(202,96%,28%); }
 
+    /* ── Narrow trigger: icon-only (magnifying glass + barcode), right-aligned ── */
+    @media (max-width: 785px) {
+      .search-outer { display: flex; justify-content: flex-end; }
+      .input-row,
+      .input-row:focus-within,
+      .search-outer.open .input-row {
+        border: none; box-shadow: none; background: transparent;
+        padding: 0; border-radius: 8px; flex: none; gap: 6px;
+      }
+      .input-row .trigger-btn { display: none; }
+      .input-row .submit { margin-left: 0; }
+    }
+
+    /* ── Full-screen overlay — active whenever _mobileExpanded=true (any viewport) ── */
+    :host(.mobile-exp) {
+      position: fixed; inset: 0; z-index: 9000;
+      width: 100dvw; height: 100dvh;
+      display: flex; flex-direction: column;
+      background: white; overflow: hidden;
+    }
+    :host(.mobile-exp) .search-outer {
+      flex: 1; display: flex; flex-direction: column;
+    }
+    :host(.mobile-exp) .input-row { display: none; }
+    :host(.mobile-exp) .panel {
+      position: static; flex: 1;
+      width: 100%; box-sizing: border-box;
+      overflow: visible; max-height: none;
+      border: none; box-shadow: none; border-radius: 0;
+      border-top: none;
+    }
+    :host(.mobile-exp) .panel-chips { max-height: none; }
+    :host(.mobile-exp) .ac-scroll { max-height: 40vh; }
+    :host(.mobile-exp) .pf-bar { overflow: visible; flex-wrap: wrap; }
+
+    /* Back button shown at top of the expanded panel */
+    .mob-back-bar {
+      padding: 8px 12px 4px;
+      border-bottom: 1px solid hsl(0,0%,92%);
+      background: hsl(0,0%,98.5%);
+    }
+    .mob-back-btn {
+      background: none; border: none; cursor: pointer;
+      font-size: 14px; font-family: inherit; color: hsl(202,96%,37%);
+      padding: 4px 0; font-weight: 500;
+    }
+    .mob-back-btn:hover { color: hsl(202,96%,28%); }
+
     @media (max-width: 600px) {
       .pf-bar { overflow-x: auto; scrollbar-width: none; flex-wrap: nowrap; }
       .pf-bar::-webkit-scrollbar { display: none; }
@@ -602,43 +669,6 @@ export class OlSearchBar extends LitElement {
       .submit { padding: 6px 10px; }
       .ac-scroll { max-height: 40vh; }
       .panel-chips { max-height: 72px; overflow-y: auto; }
-
-      /* ── Full-screen overlay (mobile-exp class toggled via JS) ── */
-      :host(.mobile-exp) {
-        position: fixed; inset: 0; z-index: 9000;
-        width: 100dvw; height: 100dvh;
-        display: flex; flex-direction: column;
-        background: white; overflow: hidden;
-      }
-      :host(.mobile-exp) .search-outer {
-        flex-shrink: 0; padding: 10px 12px;
-        border-bottom: 1.5px solid hsl(202,96%,37%);
-      }
-      :host(.mobile-exp) .search-outer.open .input-row {
-        border-bottom-left-radius: 8px;
-        border-bottom-right-radius: 8px;
-      }
-      :host(.mobile-exp) .panel {
-        position: static; flex: 1;
-        overflow-y: auto; max-height: none;
-        border: none; box-shadow: none; border-radius: 0;
-        border-top: none;
-      }
-      :host(.mobile-exp) .panel-chips { max-height: none; }
-      :host(.mobile-exp) .ac-scroll { max-height: none; }
-
-      /* Back button shown at top of the expanded panel */
-      .mob-back-bar {
-        padding: 8px 12px 4px;
-        border-bottom: 1px solid hsl(0,0%,92%);
-        background: hsl(0,0%,98.5%);
-      }
-      .mob-back-btn {
-        background: none; border: none; cursor: pointer;
-        font-size: 14px; font-family: inherit; color: hsl(202,96%,37%);
-        padding: 4px 0; font-weight: 500;
-      }
-      .mob-back-btn:hover { color: hsl(202,96%,28%); }
     }
   `;
 
@@ -700,9 +730,9 @@ export class OlSearchBar extends LitElement {
 
 
   // Order: avail → lang → genre → subject → author → sort → cog
-  _renderFacetBar(roundBottom = false) {
+  _renderFacetBar() {
     return html`
-      <div class="pf-bar ${roundBottom ? 'pf-bar--round' : ''}">
+      <div class="pf-bar">
         ${this._renderFacetBtn('avail',  false, 'pf-wrap--first')}
         ${this._renderFacetBtn('lang')}
         ${this._renderFacetBtn('genre')}
@@ -910,7 +940,7 @@ export class OlSearchBar extends LitElement {
                         aria-label="Clear all filters"
                         @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
               </div>` : ''}
-            ${this._renderFacetBar(!this._loading && !showResults)}
+            ${this._renderFacetBar()}
             ${this._renderResults(q)}
           </div>` : ''}
       </div>`;

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -82,6 +82,10 @@ export class OlSearchBar extends LitElement {
     this._subjectAbort    = null;   // AbortController for subject search
     this._lastFacetBtn    = null;   // button that opened the current facet dropdown (for focus return)
 
+    this._onWinResize = () => {
+      if (this._open) { this._open = false; this._openFacet = null; }
+    };
+
     this._onDoc = e => {
       const path = e.composedPath();
       if (!path.includes(this)) {
@@ -100,11 +104,13 @@ export class OlSearchBar extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     document.addEventListener('click', this._onDoc, true);
+    window.addEventListener('resize', this._onWinResize);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     document.removeEventListener('click', this._onDoc, true);
+    window.removeEventListener('resize', this._onWinResize);
     this._acAbort?.abort();
     this._authorAbort?.abort();
     this._subjectAbort?.abort();
@@ -128,6 +134,27 @@ export class OlSearchBar extends LitElement {
     }
     // Sync full-screen overlay class on the host element.
     this.classList.toggle('mobile-exp', this._mobileExpanded);
+    // Anchor the panel to the trigger and focus the panel-input when it opens (desktop only).
+    if (changed.has('_open') && this._open && this.showFacets && !this._mobileExpanded) {
+      this._positionPanel();
+      requestAnimationFrame(() => this.shadowRoot?.querySelector('.panel-input')?.focus());
+    }
+  }
+
+  // Set CSS custom properties on :host so the panel's position:fixed CSS vars resolve
+  // to the correct viewport-anchored coordinates. Right edge aligns with the trigger;
+  // panel extends leftward with a minimum width so facets never overflow.
+  _positionPanel() {
+    if (this._mobileExpanded) return;
+    const trigger = this.shadowRoot?.querySelector('.input-row');
+    if (!trigger) return;
+    const rect    = trigger.getBoundingClientRect();
+    const vw      = window.innerWidth;
+    const desired = Math.max(600, Math.min(860, rect.width));
+    const panelW  = Math.min(desired, rect.right - 8);
+    this.style.setProperty('--ol-panel-top',   `${rect.top}px`);
+    this.style.setProperty('--ol-panel-right', `${Math.max(0, vw - rect.right)}px`);
+    this.style.setProperty('--ol-panel-width', `${panelW}px`);
   }
 
   // ── Filter helpers ────────────────────────────────────────────
@@ -141,12 +168,13 @@ export class OlSearchBar extends LitElement {
   }
 
   // ── Autocomplete ──────────────────────────────────────────────
-  _onFocus() {
-    if (this.showFacets) {
-      this._open = true;
-      if (window.matchMedia('(max-width: 600px)').matches) {
-        this._mobileExpanded = true;
-      }
+
+  // Opens the panel overlay (droppable mode trigger click).
+  _onTriggerClick(e) {
+    e.stopPropagation();
+    this._open = true;
+    if (window.matchMedia('(max-width: 600px)').matches) {
+      this._mobileExpanded = true;
     }
     this._openFacet = null;
   }
@@ -451,13 +479,31 @@ export class OlSearchBar extends LitElement {
     .scan-btn:hover { background:hsl(0,0%,96%); border-color:hsl(0,0%,70%); }
     .scan-btn img { display:block; width:18px; height:18px; }
 
-    /* Panel (droppable mode only) */
+    /* Trigger button (droppable mode): looks like an input but opens the panel overlay */
+    .trigger-btn {
+      flex:1; min-width:0; border:none; outline:none; cursor:pointer;
+      background:transparent; font-size:14px; font-family:inherit;
+      padding:2px 4px; text-align:left; color:hsl(0,0%,15%);
+    }
+    .trigger-placeholder { color:hsl(0,0%,52%); }
+
+    /* Panel-input row: real search input that lives inside the panel overlay */
+    .panel-input-row {
+      display:flex; align-items:center; gap:5px;
+      padding:6px 8px; border-bottom:1px solid hsl(0,0%,90%);
+      background:white;
+    }
+
+    /* Panel (droppable mode only) — position driven by CSS custom props set in _positionPanel() */
     .panel {
-      position:absolute; top:calc(100% - 1.5px); left:0; right:0;
+      position:fixed;
+      top:var(--ol-panel-top, auto);
+      right:var(--ol-panel-right, 0px);
+      width:var(--ol-panel-width, 600px);
+      left:auto;
       background:white;
       border:1.5px solid hsl(202,96%,37%);
-      border-top:none;
-      border-radius:0 0 8px 8px;
+      border-radius:8px;
       box-shadow:0 12px 32px rgba(0,0,0,.16);
       z-index:500; overflow:visible;
     }
@@ -550,7 +596,6 @@ export class OlSearchBar extends LitElement {
     .ac-see-all:hover { background:hsl(202,96%,28%); }
 
     @media (max-width: 600px) {
-      .panel { left: -4px; right: -4px; max-height: 80vh; overflow-y: auto; }
       .pf-bar { overflow-x: auto; scrollbar-width: none; flex-wrap: nowrap; }
       .pf-bar::-webkit-scrollbar { display: none; }
       .pf-btn { font-size: 10px; padding: 11px 4px; }
@@ -672,72 +717,151 @@ export class OlSearchBar extends LitElement {
       <ol-howto-modal .open=${this._howtoOpen} @close=${() => this._howtoOpen = false}></ol-howto-modal>`;
   }
 
-  // ── Render ────────────────────────────────────────────────────
-  render() {
-    const q = this._q.trim();
-    const showResults = q.length >= 2 || this._hasActiveFilters();
-
-    // Droppable: derive chips from local filter state.
-    // Embedded: use chips prop passed in by the parent.
-    const chips = this.showFacets
-      ? buildChips(this._localFilters)
-      : (this.chips ?? []);
-
-    const chipItems = chips.map(c => html`
+  // ── Shared render helpers ──────────────────────────────────────
+  _renderChipItems(chips) {
+    return chips.map(c => html`
       <span class="chip chip-${c.type}">
         ${c.label}
         <button class="chip-x"
                 @click=${e => { e.stopPropagation(); this._handleChipRemove(c); }}>×</button>
       </span>`);
+  }
 
+  _renderResults(q) {
+    const showResults = q.length >= 2 || this._hasActiveFilters();
+    if (this._loading) return html`<div class="ac-spin" role="status" aria-live="polite">Searching…</div>`;
+    if (!showResults)  return html`<div class="ac-hint-msg" aria-live="polite">Start typing to search, or pick a filter above…</div>`;
     return html`
-      <div class="search-outer ${this._open ? 'open' : ''}"
-           role="search">
-        <div class="input-row">
-          <div class="input-controls">
-            <input class="text-input" type="text" autocomplete="off"
-                   placeholder="${this.placeholder}" .value=${this._q}
-                   role="combobox"
-                   aria-label="${this.placeholder}"
-                   aria-expanded=${this._open && this.showFacets ? 'true' : 'false'}
-                   aria-autocomplete="list"
-                   aria-haspopup="listbox"
-                   aria-controls="ac-listbox"
-                   aria-activedescendant=${this._acFocusIdx >= 0 ? `ac-opt-${this._acFocusIdx}` : nothing}
-                   @focus=${this._onFocus}
-                   @input=${this._onInput}
-                   @keydown=${this._onKeyDown}>
+      <div class="ac-scroll" id="ac-listbox" role="listbox" aria-label="Search suggestions">
+        ${this._suggestions.length === 0
+          ? html`<div class="ac-empty" aria-live="polite">No results</div>`
+          : this._suggestions.map((w, idx) => {
+              const ed = bestEdition(w.editions);
+              const coverId = ed?.cover_i ?? w.cover_i;
+              const edOlid  = ed?.key?.split('/').pop();
+              const wOlid   = w.key?.split('/').pop();
+              const linkKey = ed?.key ?? w.key;
+              const access  = ed?.ebook_access ?? w.ebook_access;
+              const cover = edOlid  ? `https://covers.openlibrary.org/b/olid/${edOlid}-S.jpg`
+                          : coverId ? `https://covers.openlibrary.org/b/id/${coverId}-S.jpg`
+                          : wOlid   ? `https://covers.openlibrary.org/b/olid/${wOlid}-S.jpg`
+                          : null;
+              const isReadable = access === 'public' || access === 'borrowable';
+              return html`
+                <a class="ac-row ${this._acFocusIdx === idx ? 'focused' : ''}"
+                   id="ac-opt-${idx}"
+                   href="${this.siteBase}${linkKey}"
+                   target="_blank" rel="noopener"
+                   role="option"
+                   @click=${() => this._open = false}>
+                  ${cover
+                    ? html`<img class="ac-cover" src=${cover} alt="" loading="lazy">`
+                    : html`<div class="ac-blank">📖</div>`}
+                  <div class="ac-body">
+                    <div class="ac-title">${ed?.title ?? w.title}</div>
+                    <div class="ac-author">${(w.author_name ?? []).slice(0,2).join(', ')}</div>
+                    ${w.first_publish_year ? html`<div class="ac-year">${w.first_publish_year}</div>` : ''}
+                  </div>
+                  <div class="ac-meta">
+                    <span class="ac-badge ${isReadable ? 'ac-badge--readable' : 'ac-badge--catalog'}">
+                      ${isReadable ? 'Readable' : 'Catalog'}
+                    </span>
+                    ${w.ratings_average
+                      ? html`<span class="ac-star">★ ${w.ratings_average.toFixed(1)}</span>`
+                      : ''}
+                  </div>
+                </a>`;})}
+      </div>
+      <div class="ac-foot">
+        <a class="ac-add-book" href="${this.siteBase}/books/add"
+           target="_blank" rel="noopener"
+           @click=${e => e.stopPropagation()}>+ Add Book</a>
+        <button class="ac-see-all" @click=${() => {
+          this._open = false;
+          if (!q && !this._hasActiveFilters()) return;
+          this.dispatchEvent(new CustomEvent('ol-search', {
+            detail: { q, filters: this._localFilters }, bubbles: true, composed: true,
+          }));
+        }}>See all ${this._total.toLocaleString()} results →</button>
+      </div>`;
+  }
 
-            ${this._q ? html`
-              <button class="clear-btn" aria-label="Clear search"
-                      @click=${e => { e.stopPropagation(); this._clearInput(); }}>✕</button>
-            ` : ''}
+  // ── Render ────────────────────────────────────────────────────
+  render() {
+    const q        = this._q.trim();
+    const chips    = this.showFacets ? buildChips(this._localFilters) : (this.chips ?? []);
+    const chipItems = this._renderChipItems(chips);
 
-            <button class="submit" @click=${() => this._submit()} aria-label="Search">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-                <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
-              </svg>
-            </button>
-            <span class="scan-sep"></span>
-            <a class="scan-btn" title="Scan ISBN barcode"
-               href="${this.siteBase}/barcodescanner?returnTo=/isbn/$$$"
-               target="_blank" rel="noopener"
-               @click=${e => e.stopPropagation()}>
-              <img src="${this.siteBase}/static/images/icons/barcode_scanner.svg"
-                   alt="Scan barcode" width="18" height="18">
-            </a>
+    // ── Embedded (search-page) mode: real input, no panel ────────
+    if (!this.showFacets) {
+      return html`
+        <div class="search-outer" role="search">
+          <div class="input-row">
+            <div class="input-controls">
+              <input class="text-input" type="text" autocomplete="off"
+                     placeholder="${this.placeholder}" .value=${this._q}
+                     @input=${this._onInput}
+                     @keydown=${this._onKeyDown}>
+              ${this._q ? html`
+                <button class="clear-btn" aria-label="Clear search"
+                        @click=${e => { e.stopPropagation(); this._clearInput(); }}>✕</button>
+              ` : ''}
+              <button class="submit" @click=${() => this._submit()} aria-label="Search">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+                </svg>
+              </button>
+              <span class="scan-sep"></span>
+              <a class="scan-btn" title="Scan ISBN barcode"
+                 href="${this.siteBase}/barcodescanner?returnTo=/isbn/$$$"
+                 target="_blank" rel="noopener"
+                 @click=${e => e.stopPropagation()}>
+                <img src="${this.siteBase}/static/images/icons/barcode_scanner.svg"
+                     alt="Scan barcode" width="18" height="18">
+              </a>
+            </div>
           </div>
+          ${chips.length ? html`
+            <div class="chip-bar">
+              ${chipItems}
+              ${this._hasActiveFilters() ? html`<button class="clear-all-btn"
+                      aria-label="Clear all filters"
+                      @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
+            </div>` : ''}
+        </div>`;
+    }
+
+    // ── Droppable (header) mode: trigger button + fixed panel overlay ──
+    const showResults = q.length >= 2 || this._hasActiveFilters();
+    return html`
+      <div class="search-outer ${this._open ? 'open' : ''}" role="search">
+
+        <!-- Trigger: a styled button that looks like a search input but opens the panel -->
+        <div class="input-row">
+          <button class="trigger-btn"
+                  @click=${this._onTriggerClick}
+                  aria-expanded=${this._open ? 'true' : 'false'}
+                  aria-haspopup="dialog"
+                  aria-label="${this.placeholder}">
+            <span class="${!this._q ? 'trigger-placeholder' : ''}">${this._q || this.placeholder}</span>
+          </button>
+          <button class="submit" @click=${this._onTriggerClick} aria-label="Search">
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+            </svg>
+          </button>
+          <span class="scan-sep"></span>
+          <a class="scan-btn" title="Scan ISBN barcode"
+             href="${this.siteBase}/barcodescanner?returnTo=/isbn/$$$"
+             target="_blank" rel="noopener"
+             @click=${e => e.stopPropagation()}>
+            <img src="${this.siteBase}/static/images/icons/barcode_scanner.svg"
+                 alt="Scan barcode" width="18" height="18">
+          </a>
         </div>
 
-        ${!this.showFacets && chips.length ? html`
-          <div class="chip-bar">
-            ${chipItems}
-            ${this._hasActiveFilters() ? html`<button class="clear-all-btn"
-                    aria-label="Clear all filters"
-                    @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
-          </div>` : ''}
-
-        ${this.showFacets && this._open ? html`
+        <!-- Panel overlay (position:fixed via CSS vars set by _positionPanel) -->
+        ${this._open ? html`
           <div class="panel">
             ${this._mobileExpanded ? html`
               <div class="mob-back-bar">
@@ -746,6 +870,39 @@ export class OlSearchBar extends LitElement {
                   ← Back
                 </button>
               </div>` : nothing}
+
+            <!-- Real search input at top of panel -->
+            <div class="panel-input-row">
+              <input class="text-input panel-input" type="text" autocomplete="off"
+                     placeholder="${this.placeholder}" .value=${this._q}
+                     role="combobox"
+                     aria-label="${this.placeholder}"
+                     aria-expanded="true"
+                     aria-autocomplete="list"
+                     aria-haspopup="listbox"
+                     aria-controls="ac-listbox"
+                     aria-activedescendant=${this._acFocusIdx >= 0 ? `ac-opt-${this._acFocusIdx}` : nothing}
+                     @input=${this._onInput}
+                     @keydown=${this._onKeyDown}>
+              ${this._q ? html`
+                <button class="clear-btn" aria-label="Clear search"
+                        @click=${e => { e.stopPropagation(); this._clearInput(); }}>✕</button>
+              ` : ''}
+              <button class="submit" @click=${() => this._submit()} aria-label="Search">
+                <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                  <path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0z"/>
+                </svg>
+              </button>
+              <span class="scan-sep"></span>
+              <a class="scan-btn" title="Scan ISBN barcode"
+                 href="${this.siteBase}/barcodescanner?returnTo=/isbn/$$$"
+                 target="_blank" rel="noopener"
+                 @click=${e => e.stopPropagation()}>
+                <img src="${this.siteBase}/static/images/icons/barcode_scanner.svg"
+                     alt="Scan barcode" width="18" height="18">
+              </a>
+            </div>
+
             ${chips.length ? html`
               <div class="panel-chips">
                 ${chipItems}
@@ -754,64 +911,9 @@ export class OlSearchBar extends LitElement {
                         @click=${e => { e.stopPropagation(); this._clearAllFilters(); }}>Clear all</button>` : ''}
               </div>` : ''}
             ${this._renderFacetBar(!this._loading && !showResults)}
-
-            ${this._loading ? html`<div class="ac-spin" role="status" aria-live="polite">Searching…</div>` : showResults ? html`
-              <div class="ac-scroll" id="ac-listbox" role="listbox" aria-label="Search suggestions">
-                ${this._suggestions.length === 0
-                  ? html`<div class="ac-empty" aria-live="polite">No results</div>`
-                  : this._suggestions.map((w, idx) => {
-                      const ed = bestEdition(w.editions);
-                      const coverId = ed?.cover_i ?? w.cover_i;
-                      const edOlid  = ed?.key?.split('/').pop();
-                      const wOlid   = w.key?.split('/').pop();
-                      const linkKey = ed?.key ?? w.key;
-                      const access  = ed?.ebook_access ?? w.ebook_access;
-                      const cover = edOlid  ? `https://covers.openlibrary.org/b/olid/${edOlid}-S.jpg`
-                                  : coverId ? `https://covers.openlibrary.org/b/id/${coverId}-S.jpg`
-                                  : wOlid   ? `https://covers.openlibrary.org/b/olid/${wOlid}-S.jpg`
-                                  : null;
-                      const isReadable = access === 'public' || access === 'borrowable';
-                      return html`
-                        <a class="ac-row ${this._acFocusIdx === idx ? 'focused' : ''}"
-                           id="ac-opt-${idx}"
-                           href="${this.siteBase}${linkKey}"
-                           target="_blank" rel="noopener"
-                           role="option"
-                           @click=${() => this._open = false}>
-                          ${cover
-                            ? html`<img class="ac-cover" src=${cover} alt="" loading="lazy">`
-                            : html`<div class="ac-blank">📖</div>`}
-                          <div class="ac-body">
-                            <div class="ac-title">${ed?.title ?? w.title}</div>
-                            <div class="ac-author">${(w.author_name ?? []).slice(0,2).join(', ')}</div>
-                            ${w.first_publish_year ? html`<div class="ac-year">${w.first_publish_year}</div>` : ''}
-                          </div>
-                          <div class="ac-meta">
-                            <span class="ac-badge ${isReadable ? 'ac-badge--readable' : 'ac-badge--catalog'}">
-                              ${isReadable ? 'Readable' : 'Catalog'}
-                            </span>
-                            ${w.ratings_average
-                              ? html`<span class="ac-star">★ ${w.ratings_average.toFixed(1)}</span>`
-                              : ''}
-                          </div>
-                        </a>`;})}
-              </div>
-              <div class="ac-foot">
-                <a class="ac-add-book" href="${this.siteBase}/books/add"
-                   target="_blank" rel="noopener"
-                   @click=${e => e.stopPropagation()}>+ Add Book</a>
-                <button class="ac-see-all" @click=${() => {
-                  this._open = false;
-                  if (!q && !this._hasActiveFilters()) return;
-                  this.dispatchEvent(new CustomEvent('ol-search', {
-                    detail: { q, filters: this._localFilters }, bubbles: true, composed: true,
-                  }));
-                }}>See all ${this._total.toLocaleString()} results →</button>
-              </div>
-            ` : html`<div class="ac-hint-msg" aria-live="polite">Start typing to search, or pick a filter above…</div>`}
+            ${this._renderResults(q)}
           </div>` : ''}
-      </div>
-    `;
+      </div>`;
   }
 }
 

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -69,8 +69,9 @@ describe('ol-search-bar mobile overlay JS contract', () => {
     expect(src).toMatch(/this\._mobileExpanded\s*=\s*false/);
   });
 
-  it('sets _mobileExpanded = true in _onFocus when on mobile', () => {
-    expect(src).toMatch(/_mobileExpanded\s*=\s*true/);
+  it('sets _mobileExpanded = true in _onTriggerClick on narrow viewports', () => {
+    const fn = src.slice(src.indexOf('_onTriggerClick'), src.indexOf('_onTriggerClick') + 300);
+    expect(fn).toMatch(/_mobileExpanded\s*=\s*true/);
   });
 
   it('clears _mobileExpanded in _onKeyDown Escape path', () => {

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -3,56 +3,60 @@ import { describe, it, expect } from 'vitest';
 
 const src = readFileSync(new URL('./ol-search-bar.js', import.meta.url), 'utf8');
 
-// Pull out just the @media (max-width: 600px) block by brace-counting
-function extractMediaBlock(source, startToken) {
-  const idx = source.indexOf(startToken);
-  if (idx === -1) return '';
-  let depth = 0;
-  for (let i = idx; i < source.length; i++) {
-    if (source[i] === '{') depth++;
-    else if (source[i] === '}') {
-      depth--;
-      if (depth === 0) return source.slice(idx, i + 1);
-    }
-  }
-  return '';
-}
-
-const mobileBlock = extractMediaBlock(src, '@media (max-width: 600px)');
+// :host(.mobile-exp) rules are now standalone (not inside a media query) so we
+// search the full source rather than a media block.
 
 describe('ol-search-bar mobile overlay CSS contract', () => {
-  it('has :host(.mobile-exp) rule inside the mobile media block', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)/);
+  it('has :host(.mobile-exp) rule in the component styles', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)/);
   });
 
   it(':host(.mobile-exp) uses position: fixed for a true viewport overlay', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*position\s*:\s*fixed/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)[^}]*position\s*:\s*fixed/);
   });
 
   it(':host(.mobile-exp) has z-index of at least 9000 to sit above all other content', () => {
-    const match = mobileBlock.match(/:host\(\.mobile-exp\)[^}]*z-index\s*:\s*(\d+)/);
+    const match = src.match(/:host\(\.mobile-exp\)[^}]*z-index\s*:\s*(\d+)/);
     expect(match).not.toBeNull();
     expect(parseInt(match[1], 10)).toBeGreaterThanOrEqual(9000);
   });
 
   it(':host(.mobile-exp) covers the full dynamic viewport height with 100dvh', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*height\s*:\s*100dvh/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)[^}]*height\s*:\s*100dvh/);
   });
 
   it(':host(.mobile-exp) stretches to full width with 100dvw', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)[^}]*width\s*:\s*100dvw/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)[^}]*width\s*:\s*100dvw/);
   });
 
   it(':host(.mobile-exp) .panel resets to static positioning (not absolute)', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
   });
 
   it(':host(.mobile-exp) .panel removes max-height constraint', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*max-height\s*:\s*none/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*max-height\s*:\s*none/);
   });
 
-  it(':host(.mobile-exp) .ac-scroll removes max-height constraint', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.ac-scroll[^}]*max-height\s*:\s*none/);
+  it(':host(.mobile-exp) .ac-scroll has a vh-based max-height for results scrolling', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.ac-scroll[^}]*max-height\s*:\s*\d+vh/);
+  });
+
+  it(':host(.mobile-exp) .panel sets width:100% to override the desktop CSS var', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*width\s*:\s*100%/);
+  });
+
+  it(':host(.mobile-exp) .panel uses overflow:visible so facet dropdowns are not clipped', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*overflow\s*:\s*visible/);
+  });
+});
+
+describe('ol-search-bar mobile overlay — facet dropdown clipping fix', () => {
+  it(':host(.mobile-exp) .pf-bar overrides overflow to visible so ol-facet-drop is not clipped', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.pf-bar[^}]*overflow\s*:\s*visible/);
+  });
+
+  it(':host(.mobile-exp) .pf-bar uses flex-wrap: wrap so buttons stay visible instead of scrolling off-screen', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.pf-bar[^}]*flex-wrap\s*:\s*wrap/);
   });
 });
 
@@ -70,7 +74,6 @@ describe('ol-search-bar mobile overlay JS contract', () => {
   });
 
   it('clears _mobileExpanded in _onKeyDown Escape path', () => {
-    // Escape handler should reset the overlay
     const escapeBlock = src.slice(src.indexOf("key === 'Escape'"), src.indexOf("key === 'Escape'") + 200);
     expect(escapeBlock).toMatch(/_mobileExpanded\s*=\s*false/);
   });

--- a/frontend/src/components/ol-search-bar.mobile2.test.js
+++ b/frontend/src/components/ol-search-bar.mobile2.test.js
@@ -25,14 +25,6 @@ describe('ol-search-bar mobile Phase 2 CSS contract', () => {
     expect(mediaIdx).not.toBe(-1);
   });
 
-  it('.panel has max-height: 80vh to prevent full-screen overlay with virtual keyboard open', () => {
-    expect(mobileBlock).toMatch(/\.panel[^{]*\{[^}]*max-height\s*:\s*80vh/);
-  });
-
-  it('.panel has overflow-y: auto for inner scrolling', () => {
-    expect(mobileBlock).toMatch(/\.panel[^{]*\{[^}]*overflow-y\s*:\s*auto/);
-  });
-
   it('.ac-scroll max-height uses vh (not px) so it respects virtual keyboard', () => {
     const match = mobileBlock.match(/\.ac-scroll[^{]*\{[^}]*max-height\s*:\s*(\S+)/);
     expect(match).not.toBeNull();

--- a/frontend/src/components/ol-search-bar.mobile2.test.js
+++ b/frontend/src/components/ol-search-bar.mobile2.test.js
@@ -20,6 +20,35 @@ function extractMediaBlock(source, idx) {
 }
 const mobileBlock = mediaIdx !== -1 ? extractMediaBlock(src, mediaIdx) : '';
 
+const narrowIdx   = src.indexOf('@media (max-width: 785px)');
+const narrowBlock = narrowIdx !== -1 ? extractMediaBlock(src, narrowIdx) : '';
+
+describe('ol-search-bar narrow trigger — icon-only mode at ≤785px', () => {
+  it('has a @media (max-width: 785px) block', () => {
+    expect(narrowIdx).not.toBe(-1);
+  });
+
+  it('hides .trigger-btn so only the icons remain', () => {
+    expect(narrowBlock).toMatch(/\.input-row\s+\.trigger-btn[^}]*display\s*:\s*none/);
+  });
+
+  it('keeps .scan-btn visible (does not hide it)', () => {
+    expect(narrowBlock).not.toMatch(/\.scan-btn[^}]*display\s*:\s*none/);
+  });
+
+  it('removes .input-row border so the row does not look like a text input', () => {
+    expect(narrowBlock).toMatch(/\.input-row[^{]*\{[^}]*border\s*:\s*none/);
+  });
+
+  it('removes .input-row box-shadow at narrow width', () => {
+    expect(narrowBlock).toMatch(/\.input-row[^{]*\{[^}]*box-shadow\s*:\s*none/);
+  });
+
+  it('right-aligns the icon group via justify-content: flex-end on .search-outer', () => {
+    expect(narrowBlock).toMatch(/\.search-outer[^{]*\{[^}]*justify-content\s*:\s*flex-end/);
+  });
+});
+
 describe('ol-search-bar mobile Phase 2 CSS contract', () => {
   it('has a @media (max-width: 600px) block', () => {
     expect(mediaIdx).not.toBe(-1);

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -3,21 +3,6 @@ import { describe, it, expect } from 'vitest';
 
 const src = readFileSync(new URL('./ol-search-bar.js', import.meta.url), 'utf8');
 
-// ── CSS helpers ───────────────────────────────────────────────────────────────
-
-function extractBlock(source, startToken) {
-  const idx = source.indexOf(startToken);
-  if (idx === -1) return '';
-  let depth = 0;
-  for (let i = idx; i < source.length; i++) {
-    if (source[i] === '{') depth++;
-    else if (source[i] === '}') { depth--; if (depth === 0) return source.slice(idx, i + 1); }
-  }
-  return '';
-}
-
-// :host(.mobile-exp) rules are now standalone — search full src, not a media block.
-const mobileBlock  = extractBlock(src, '@media (max-width: 600px)');
 const panelCssIdx  = src.indexOf('.panel {');
 const panelCssEnd  = src.indexOf('}', panelCssIdx);
 const panelCss     = panelCssIdx !== -1 ? src.slice(panelCssIdx, panelCssEnd + 1) : '';

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -1,0 +1,146 @@
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const src = readFileSync(new URL('./ol-search-bar.js', import.meta.url), 'utf8');
+
+// ── CSS helpers ───────────────────────────────────────────────────────────────
+
+function extractBlock(source, startToken) {
+  const idx = source.indexOf(startToken);
+  if (idx === -1) return '';
+  let depth = 0;
+  for (let i = idx; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') { depth--; if (depth === 0) return source.slice(idx, i + 1); }
+  }
+  return '';
+}
+
+const mobileBlock  = extractBlock(src, '@media (max-width: 600px)');
+const panelCssIdx  = src.indexOf('.panel {');
+const panelCssEnd  = src.indexOf('}', panelCssIdx);
+const panelCss     = panelCssIdx !== -1 ? src.slice(panelCssIdx, panelCssEnd + 1) : '';
+
+// ── Panel CSS contract ────────────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — CSS positioning contract', () => {
+  it('panel base rule uses position:fixed so it escapes header width constraints', () => {
+    expect(panelCss).toMatch(/position\s*:\s*fixed/);
+  });
+
+  it('panel top is driven by --ol-panel-top CSS custom property', () => {
+    expect(panelCss).toMatch(/top\s*:\s*var\(--ol-panel-top/);
+  });
+
+  it('panel right is driven by --ol-panel-right CSS custom property', () => {
+    expect(panelCss).toMatch(/right\s*:\s*var\(--ol-panel-right/);
+  });
+
+  it('panel width is driven by --ol-panel-width CSS custom property', () => {
+    expect(panelCss).toMatch(/width\s*:\s*var\(--ol-panel-width/);
+  });
+
+  it('panel left is auto so right+width control placement (not stretched)', () => {
+    expect(panelCss).toMatch(/left\s*:\s*auto/);
+  });
+});
+
+// ── _positionPanel JS contract ────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — _positionPanel JS contract', () => {
+  // Find the method definition (not call sites like _positionPanel();) by including the brace.
+  const fnStart = src.indexOf('_positionPanel() {');
+  const fnBody  = fnStart !== -1 ? src.slice(fnStart, fnStart + 800) : '';
+
+  it('_positionPanel method exists', () => {
+    expect(fnStart).not.toBe(-1);
+  });
+
+  it('_positionPanel sets --ol-panel-top via setProperty on the host', () => {
+    expect(fnBody).toMatch(/setProperty\s*\(\s*['"]--ol-panel-top['"]/);
+  });
+
+  it('_positionPanel sets --ol-panel-right via setProperty on the host', () => {
+    expect(fnBody).toMatch(/setProperty\s*\(\s*['"]--ol-panel-right['"]/);
+  });
+
+  it('_positionPanel sets --ol-panel-width via setProperty on the host', () => {
+    expect(fnBody).toMatch(/setProperty\s*\(\s*['"]--ol-panel-width['"]/);
+  });
+
+  it('_positionPanel enforces a minimum panel width of 600px', () => {
+    expect(fnBody).toMatch(/Math\.max\s*\(\s*600/);
+  });
+
+  it('_positionPanel skips positioning when _mobileExpanded is true', () => {
+    expect(fnBody).toMatch(/_mobileExpanded.*return|return.*_mobileExpanded/s);
+  });
+
+  it('_positionPanel reads getBoundingClientRect from the trigger element', () => {
+    expect(fnBody).toMatch(/getBoundingClientRect/);
+  });
+});
+
+// ── Trigger button contract ───────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — trigger button contract', () => {
+  it('has a .trigger-btn CSS class', () => {
+    expect(src).toMatch(/\.trigger-btn/);
+  });
+
+  it('has _onTriggerClick event handler', () => {
+    expect(src).toMatch(/_onTriggerClick/);
+  });
+
+  it('trigger-btn is wired to _onTriggerClick in the template', () => {
+    expect(src).toMatch(/trigger-btn[\s\S]{0,200}_onTriggerClick|_onTriggerClick[\s\S]{0,200}trigger-btn/);
+  });
+});
+
+// ── Panel-input contract ──────────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — panel-input contract', () => {
+  it('panel-input-row container exists in CSS', () => {
+    expect(src).toMatch(/\.panel-input-row/);
+  });
+
+  it('panel-input class is used on the real input inside the panel', () => {
+    expect(src).toMatch(/panel-input/);
+  });
+
+  it('updated() focuses the panel-input when the panel opens', () => {
+    const updFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 1000);
+    expect(updFn).toMatch(/panel-input/);
+  });
+});
+
+// ── Window resize contract ────────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — window resize contract', () => {
+  it('_onWinResize handler is defined', () => {
+    expect(src).toMatch(/_onWinResize/);
+  });
+
+  it('resize listener is added in connectedCallback', () => {
+    const cb = src.slice(src.indexOf('connectedCallback'), src.indexOf('connectedCallback') + 300);
+    expect(cb).toMatch(/addEventListener\s*\(\s*['"]resize['"]/);
+  });
+
+  it('resize listener is removed in disconnectedCallback', () => {
+    const cb = src.slice(src.indexOf('disconnectedCallback'), src.indexOf('disconnectedCallback') + 300);
+    expect(cb).toMatch(/removeEventListener\s*\(\s*['"]resize['"]/);
+  });
+});
+
+// ── Mobile overlay regression ─────────────────────────────────────────────────
+
+describe('ol-search-bar panel overlay — mobile overlay not broken', () => {
+  it('mobile overlay still overrides panel to position:static', () => {
+    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
+  });
+
+  it('_onTriggerClick sets _mobileExpanded=true on narrow viewports', () => {
+    const fn = src.slice(src.indexOf('_onTriggerClick'), src.indexOf('_onTriggerClick') + 300);
+    expect(fn).toMatch(/_mobileExpanded\s*=\s*true/);
+  });
+});

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -16,6 +16,7 @@ function extractBlock(source, startToken) {
   return '';
 }
 
+// :host(.mobile-exp) rules are now standalone — search full src, not a media block.
 const mobileBlock  = extractBlock(src, '@media (max-width: 600px)');
 const panelCssIdx  = src.indexOf('.panel {');
 const panelCssEnd  = src.indexOf('}', panelCssIdx);
@@ -40,8 +41,8 @@ describe('ol-search-bar panel overlay — CSS positioning contract', () => {
     expect(panelCss).toMatch(/width\s*:\s*var\(--ol-panel-width/);
   });
 
-  it('panel left is auto so right+width control placement (not stretched)', () => {
-    expect(panelCss).toMatch(/left\s*:\s*auto/);
+  it('panel left is driven by --ol-panel-left CSS custom property', () => {
+    expect(panelCss).toMatch(/left\s*:\s*var\(--ol-panel-left/);
   });
 });
 
@@ -78,6 +79,10 @@ describe('ol-search-bar panel overlay — _positionPanel JS contract', () => {
 
   it('_positionPanel reads getBoundingClientRect from the trigger element', () => {
     expect(fnBody).toMatch(/getBoundingClientRect/);
+  });
+
+  it('_positionPanel sets --ol-panel-left via setProperty on the host', () => {
+    expect(fnBody).toMatch(/setProperty\s*\(\s*['"]--ol-panel-left['"]/);
   });
 });
 
@@ -130,17 +135,34 @@ describe('ol-search-bar panel overlay — window resize contract', () => {
     const cb = src.slice(src.indexOf('disconnectedCallback'), src.indexOf('disconnectedCallback') + 300);
     expect(cb).toMatch(/removeEventListener\s*\(\s*['"]resize['"]/);
   });
+
+  it('_onWinResize calls _positionPanel to reposition (does not just close the panel)', () => {
+    const fnIdx = src.indexOf('_onWinResize =');
+    const fnBody = fnIdx !== -1 ? src.slice(fnIdx, fnIdx + 500) : '';
+    expect(fnBody).toMatch(/_positionPanel/);
+  });
+
+  it('_onWinResize sets _mobileExpanded=true when viewport shrinks into mobile', () => {
+    const fnIdx = src.indexOf('_onWinResize =');
+    const fnBody = fnIdx !== -1 ? src.slice(fnIdx, fnIdx + 500) : '';
+    // isMobile branch must set _mobileExpanded = true
+    expect(fnBody).toMatch(/isMobile[\s\S]{0,80}_mobileExpanded\s*=\s*true/);
+  });
 });
 
 // ── Mobile overlay regression ─────────────────────────────────────────────────
 
 describe('ol-search-bar panel overlay — mobile overlay not broken', () => {
   it('mobile overlay still overrides panel to position:static', () => {
-    expect(mobileBlock).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*position\s*:\s*static/);
   });
 
   it('_onTriggerClick sets _mobileExpanded=true on narrow viewports', () => {
     const fn = src.slice(src.indexOf('_onTriggerClick'), src.indexOf('_onTriggerClick') + 300);
     expect(fn).toMatch(/_mobileExpanded\s*=\s*true/);
+  });
+
+  it('mobile overlay hides the trigger .input-row so two search inputs are not visible', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.input-row[^}]*display\s*:\s*none/);
   });
 });

--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -9,6 +9,7 @@ import {
   EMPTY_FILTERS, buildChips, buildSearchParams, shufflePick,
   getSortLabel,
 } from '../utils/filters.js';
+import { fetchAuthorSuggestions, fetchSubjectSuggestions } from '../utils/facets.js';
 
 const LIMIT = 20;
 
@@ -352,8 +353,11 @@ export class OlSearchPage extends LitElement {
     const q = e.detail.q;
     if (q.trim().length < 2) { this._authorResults = []; return; }
     this._authorTimer = setTimeout(async () => {
-      const d = await (await fetch(`/api/authors/search?q=${encodeURIComponent(q.trim())}&limit=8`)).json();
-      this._authorResults = d.docs ?? [];
+      try {
+        this._authorResults = await fetchAuthorSuggestions(q);
+      } catch {
+        this._authorResults = [];
+      }
     }, 250);
   }
 
@@ -362,8 +366,11 @@ export class OlSearchPage extends LitElement {
     const q = e.detail.q;
     if (q.trim().length < 2) { this._subjectResults = []; return; }
     this._subjectTimer = setTimeout(async () => {
-      const d = await (await fetch(`/api/subjects/search?q=${encodeURIComponent(q.trim())}&limit=8`)).json();
-      this._subjectResults = d.docs ?? [];
+      try {
+        this._subjectResults = await fetchSubjectSuggestions(q);
+      } catch {
+        this._subjectResults = [];
+      }
     }, 250);
   }
 

--- a/frontend/src/utils/breakpoints.js
+++ b/frontend/src/utils/breakpoints.js
@@ -1,0 +1,11 @@
+// Central viewport breakpoint constants — single source of truth for all JS
+// matchMedia checks and the _positionPanel thresholds in ol-search-bar.
+//
+// CSS media queries in component stylesheets must duplicate these numbers as
+// literals (Lit template literals are not preprocessed), so changes here must
+// be manually mirrored in the relevant @media blocks.
+export const BREAKPOINTS = {
+  mobile: 600,  // full-screen overlay threshold (JS + CSS @media)
+  narrow: 785,  // icon-only trigger in header   (CSS @media only)
+  wide:   900,  // panel right-align vs. centered (JS _positionPanel only)
+};

--- a/frontend/src/utils/breakpoints.test.js
+++ b/frontend/src/utils/breakpoints.test.js
@@ -1,0 +1,85 @@
+/**
+ * TDD contract for utils/breakpoints.js — central viewport breakpoint constants.
+ *
+ * Three raw numbers currently appear scattered across ol-search-bar.js (in both
+ * JS matchMedia calls and CSS media queries) with no single source of truth:
+ *
+ *   600  — full-screen mobile overlay threshold (JS _onTriggerClick, _onWinResize + CSS)
+ *   785  — icon-only trigger (CSS-only, JS never checks this)
+ *   900  — panel right-align vs center threshold (JS _positionPanel)
+ *
+ * These tests will fail (red) until breakpoints.js is created, then pass (green).
+ * The static-analysis suite below also verifies that the JS-side matchMedia calls
+ * in ol-search-bar no longer contain raw numeric literals once the refactor is done.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { BREAKPOINTS } from './breakpoints.js';
+
+// ── Constant values ────────────────────────────────────────────────────────────
+
+describe('BREAKPOINTS constant', () => {
+  it('is exported from utils/breakpoints.js', () => {
+    expect(BREAKPOINTS).toBeDefined();
+  });
+
+  it('mobile is 600 — full-screen overlay activates below this width', () => {
+    expect(BREAKPOINTS.mobile).toBe(600);
+  });
+
+  it('narrow is 785 — icon-only trigger activates below this width', () => {
+    expect(BREAKPOINTS.narrow).toBe(785);
+  });
+
+  it('wide is 900 — panel switches from centered to right-aligned above this width', () => {
+    expect(BREAKPOINTS.wide).toBe(900);
+  });
+
+  it('all values are positive integers', () => {
+    for (const [, v] of Object.entries(BREAKPOINTS)) {
+      expect(Number.isInteger(v)).toBe(true);
+      expect(v).toBeGreaterThan(0);
+    }
+  });
+
+  it('mobile < narrow < wide (logical ordering)', () => {
+    expect(BREAKPOINTS.mobile).toBeLessThan(BREAKPOINTS.narrow);
+    expect(BREAKPOINTS.narrow).toBeLessThan(BREAKPOINTS.wide);
+  });
+});
+
+// ── Static analysis: JS source no longer hard-codes breakpoint numbers ─────────
+// These assertions become meaningful after the refactor; they ensure the raw
+// literals are not re-introduced by future edits.
+
+const searchBarSrc = readFileSync(
+  new URL('../components/ol-search-bar.js', import.meta.url), 'utf8'
+);
+
+describe('ol-search-bar.js — JS matchMedia calls use BREAKPOINTS, not raw literals', () => {
+  it('does not call matchMedia with a raw 600px literal in JS', () => {
+    // CSS template literals will still contain '600px' — narrow the match to
+    // matchMedia() call sites only.
+    const matchMediaCalls = [...searchBarSrc.matchAll(/matchMedia\s*\([^)]+\)/g)]
+      .map(m => m[0]);
+    for (const call of matchMediaCalls) {
+      expect(call).not.toContain('600px');
+    }
+  });
+
+  it('does not call matchMedia with a raw 900px literal in JS', () => {
+    const matchMediaCalls = [...searchBarSrc.matchAll(/matchMedia\s*\([^)]+\)/g)]
+      .map(m => m[0]);
+    for (const call of matchMediaCalls) {
+      expect(call).not.toContain('900px');
+    }
+  });
+
+  it('_positionPanel does not compare window.innerWidth against a raw 900 literal', () => {
+    const fnStart = searchBarSrc.indexOf('_positionPanel()');
+    const fnBody  = fnStart !== -1 ? searchBarSrc.slice(fnStart, fnStart + 600) : '';
+    // After refactor, should compare against BREAKPOINTS.wide, not > 900
+    expect(fnBody).not.toMatch(/>\s*900[^a-zA-Z]/);
+  });
+});

--- a/frontend/src/utils/facets.js
+++ b/frontend/src/utils/facets.js
@@ -1,0 +1,41 @@
+// Shared fetch helpers for author and subject typeahead suggestions.
+// Both ol-search-bar and ol-search-page used to contain verbatim copies of
+// this logic; this module is the single source of truth.
+//
+// Callers are responsible for debouncing and managing loading state.
+// AbortError (from a cancelled request) is swallowed and returns [].
+// All other errors are re-thrown so the caller can decide how to handle them.
+
+/**
+ * @param {string} q       - Raw query string (trimmed internally; < 2 chars → [])
+ * @param {{ signal?: AbortSignal, apiBase?: string }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function fetchAuthorSuggestions(q, { signal, apiBase = '' } = {}) {
+  if (q.trim().length < 2) return [];
+  try {
+    const url = `${apiBase}/api/authors/search?q=${encodeURIComponent(q.trim())}&limit=8`;
+    const d = await (await fetch(url, { signal })).json();
+    return d.docs ?? [];
+  } catch (err) {
+    if (err.name === 'AbortError') return [];
+    throw err;
+  }
+}
+
+/**
+ * @param {string} q       - Raw query string (trimmed internally; < 2 chars → [])
+ * @param {{ signal?: AbortSignal, apiBase?: string }} [opts]
+ * @returns {Promise<object[]>}
+ */
+export async function fetchSubjectSuggestions(q, { signal, apiBase = '' } = {}) {
+  if (q.trim().length < 2) return [];
+  try {
+    const url = `${apiBase}/api/subjects/search?q=${encodeURIComponent(q.trim())}&limit=8`;
+    const d = await (await fetch(url, { signal })).json();
+    return d.docs ?? [];
+  } catch (err) {
+    if (err.name === 'AbortError') return [];
+    throw err;
+  }
+}

--- a/frontend/src/utils/facets.test.js
+++ b/frontend/src/utils/facets.test.js
@@ -1,0 +1,176 @@
+/**
+ * TDD contract for utils/facets.js — shared author & subject fetch helpers.
+ *
+ * These tests are written BEFORE the module exists.  They will all fail (red)
+ * until facets.js is created, then pass (green) once the implementation is in
+ * place.  The goal is to pin the public API so future changes to either
+ * ol-search-bar or ol-search-page can be verified against a single source.
+ *
+ * Design constraints captured here:
+ *   - Short queries (< 2 trimmed chars) return [] without fetching
+ *   - Results come from d.docs, defaulting to [] on a missing key
+ *   - AbortError is swallowed and returns [] (cancelled request is not an error)
+ *   - Other fetch errors propagate to the caller
+ *   - apiBase is prepended so both components can pass their own prefix
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fetchAuthorSuggestions, fetchSubjectSuggestions } from './facets.js';
+
+afterEach(() => vi.restoreAllMocks());
+
+// ── Shared helper ──────────────────────────────────────────────────────────────
+
+function mockFetch(docs) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    json: async () => ({ docs }),
+  });
+}
+
+// ── fetchAuthorSuggestions ────────────────────────────────────────────────────
+
+describe('fetchAuthorSuggestions', () => {
+  it('is exported from utils/facets.js', () => {
+    expect(typeof fetchAuthorSuggestions).toBe('function');
+  });
+
+  it('returns [] without fetching when query is shorter than 2 chars', async () => {
+    const spy = mockFetch([]);
+    const result = await fetchAuthorSuggestions('a');
+    expect(spy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] without fetching when query is empty', async () => {
+    const spy = mockFetch([]);
+    const result = await fetchAuthorSuggestions('');
+    expect(spy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] without fetching when query is whitespace-only', async () => {
+    const spy = mockFetch([]);
+    const result = await fetchAuthorSuggestions('  ');
+    expect(spy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('calls /api/authors/search with q and limit=8', async () => {
+    const spy = mockFetch([{ name: 'Tolkien' }]);
+    await fetchAuthorSuggestions('tolkien');
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/authors/search'),
+      expect.anything(),
+    );
+    const url = spy.mock.calls[0][0];
+    expect(url).toContain('q=tolkien');
+    expect(url).toContain('limit=8');
+  });
+
+  it('prepends apiBase to the request URL', async () => {
+    const spy = mockFetch([]);
+    await fetchAuthorSuggestions('tolkien', { apiBase: 'https://example.com' });
+    expect(spy.mock.calls[0][0]).toMatch(/^https:\/\/example\.com/);
+  });
+
+  it('passes the AbortSignal to fetch', async () => {
+    const spy = mockFetch([]);
+    const ctrl = new AbortController();
+    await fetchAuthorSuggestions('tolkien', { signal: ctrl.signal });
+    expect(spy.mock.calls[0][1]).toMatchObject({ signal: ctrl.signal });
+  });
+
+  it('returns the docs array from the response', async () => {
+    const docs = [{ name: 'J.R.R. Tolkien' }, { name: 'Simon Tolkien' }];
+    mockFetch(docs);
+    const result = await fetchAuthorSuggestions('tolkien');
+    expect(result).toEqual(docs);
+  });
+
+  it('returns [] when the response has no docs key', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ json: async () => ({}) });
+    const result = await fetchAuthorSuggestions('tolkien');
+    expect(result).toEqual([]);
+  });
+
+  it('swallows AbortError and returns []', async () => {
+    const err = new DOMException('aborted', 'AbortError');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(err);
+    const result = await fetchAuthorSuggestions('tolkien');
+    expect(result).toEqual([]);
+  });
+
+  it('re-throws non-abort errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network failure'));
+    await expect(fetchAuthorSuggestions('tolkien')).rejects.toThrow('network failure');
+  });
+
+  it('URL-encodes the query', async () => {
+    const spy = mockFetch([]);
+    await fetchAuthorSuggestions('García Márquez');
+    const url = spy.mock.calls[0][0];
+    expect(url).toContain(encodeURIComponent('García Márquez'));
+  });
+});
+
+// ── fetchSubjectSuggestions ───────────────────────────────────────────────────
+
+describe('fetchSubjectSuggestions', () => {
+  it('is exported from utils/facets.js', () => {
+    expect(typeof fetchSubjectSuggestions).toBe('function');
+  });
+
+  it('returns [] without fetching when query is shorter than 2 chars', async () => {
+    const spy = mockFetch([]);
+    const result = await fetchSubjectSuggestions('x');
+    expect(spy).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it('calls /api/subjects/search with q and limit=8', async () => {
+    const spy = mockFetch([{ name: 'cooking' }]);
+    await fetchSubjectSuggestions('cooking');
+    const url = spy.mock.calls[0][0];
+    expect(url).toContain('/api/subjects/search');
+    expect(url).toContain('q=cooking');
+    expect(url).toContain('limit=8');
+  });
+
+  it('prepends apiBase to the request URL', async () => {
+    const spy = mockFetch([]);
+    await fetchSubjectSuggestions('cooking', { apiBase: 'https://example.com' });
+    expect(spy.mock.calls[0][0]).toMatch(/^https:\/\/example\.com/);
+  });
+
+  it('passes the AbortSignal to fetch', async () => {
+    const spy = mockFetch([]);
+    const ctrl = new AbortController();
+    await fetchSubjectSuggestions('cooking', { signal: ctrl.signal });
+    expect(spy.mock.calls[0][1]).toMatchObject({ signal: ctrl.signal });
+  });
+
+  it('returns the docs array from the response', async () => {
+    const docs = [{ name: 'cooking' }, { name: 'cookbooks' }];
+    mockFetch(docs);
+    const result = await fetchSubjectSuggestions('cook');
+    expect(result).toEqual(docs);
+  });
+
+  it('returns [] when the response has no docs key', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ json: async () => ({}) });
+    const result = await fetchSubjectSuggestions('cooking');
+    expect(result).toEqual([]);
+  });
+
+  it('swallows AbortError and returns []', async () => {
+    const err = new DOMException('aborted', 'AbortError');
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(err);
+    const result = await fetchSubjectSuggestions('cooking');
+    expect(result).toEqual([]);
+  });
+
+  it('re-throws non-abort errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network failure'));
+    await expect(fetchSubjectSuggestions('cooking')).rejects.toThrow('network failure');
+  });
+});

--- a/frontend/src/utils/filters.js
+++ b/frontend/src/utils/filters.js
@@ -120,7 +120,9 @@ export const POPULAR_AUTHORS = [
   'Chimamanda Ngozi Adichie', 'Kazuo Ishiguro', 'Salman Rushdie', 'Milan Kundera',
 ];
 
-export const EMPTY_FILTERS = {
+// DEFAULT_FILTERS is the canonical name — "EMPTY" was a misnomer because
+// availability defaults to 'readable', not to a truly empty state.
+export const DEFAULT_FILTERS = {
   sort:          '',
   availability:  'readable',
   fictionFilter: '',
@@ -129,6 +131,9 @@ export const EMPTY_FILTERS = {
   authors:       [],
   subjects:      [],
 };
+
+// Backward-compat alias so existing import sites don't need to change at once.
+export const EMPTY_FILTERS = DEFAULT_FILTERS;
 
 // ── Label helpers ─────────────────────────────────────────────────────────────
 

--- a/frontend/src/utils/filters.test.js
+++ b/frontend/src/utils/filters.test.js
@@ -11,6 +11,7 @@ import {
   getSortLabel,
   getFictionLabel,
   EMPTY_FILTERS,
+  DEFAULT_FILTERS,
   AVAILABILITY_OPTIONS,
   FICTION_OPTIONS,
   POPULAR_SUBJECTS,
@@ -404,5 +405,45 @@ describe('spoofAvailabilityCounts', () => {
     expect(counts['readable']).toBeLessThanOrEqual(counts['']);
     expect(counts['open']).toBeLessThanOrEqual(counts['readable']);
     expect(counts['borrowable']).toBeLessThanOrEqual(counts['readable']);
+  });
+});
+
+// ── DEFAULT_FILTERS (renamed from EMPTY_FILTERS) ──────────────────────────────
+// These tests are written BEFORE the rename and will fail (red) until
+// DEFAULT_FILTERS is exported from filters.js.  They pin three things:
+//   1. The export exists under the new name
+//   2. The non-empty default (availability:'readable') is preserved
+//   3. EMPTY_FILTERS is kept as a re-export alias so existing callers don't break
+
+describe('DEFAULT_FILTERS', () => {
+  it('is exported from filters.js', () => {
+    expect(DEFAULT_FILTERS).toBeDefined();
+  });
+
+  it('has availability set to "readable" — the non-empty default that made EMPTY_FILTERS a misnomer', () => {
+    expect(DEFAULT_FILTERS.availability).toBe('readable');
+  });
+
+  it('has fictionFilter as empty string', () => {
+    expect(DEFAULT_FILTERS.fictionFilter).toBe('');
+  });
+
+  it('has empty arrays for languages, genres, authors, subjects', () => {
+    expect(DEFAULT_FILTERS.languages).toEqual([]);
+    expect(DEFAULT_FILTERS.genres).toEqual([]);
+    expect(DEFAULT_FILTERS.authors).toEqual([]);
+    expect(DEFAULT_FILTERS.subjects).toEqual([]);
+  });
+
+  it('has sort as empty string', () => {
+    expect(DEFAULT_FILTERS.sort).toBe('');
+  });
+
+  it('has the same shape and values as EMPTY_FILTERS (backward-compat alias)', () => {
+    expect(DEFAULT_FILTERS).toEqual(EMPTY_FILTERS);
+  });
+
+  it('EMPTY_FILTERS is still exported so existing import sites do not break', () => {
+    expect(EMPTY_FILTERS).toBeDefined();
   });
 });

--- a/frontend/tests/facet-and-submit.spec.js
+++ b/frontend/tests/facet-and-submit.spec.js
@@ -1,3 +1,10 @@
+/**
+ * ol-search-bar facet dropdown dismissal (issue #21) and submit (issue #22).
+ *
+ * ol-search-bar lives inside ol-header's shadow DOM, so all page.evaluate()
+ * helpers traverse: document → ol-header.shadowRoot → ol-search-bar.
+ */
+
 import { test, expect } from '@playwright/test';
 
 async function waitForCustomElements(page) {
@@ -7,29 +14,29 @@ async function waitForCustomElements(page) {
   );
 }
 
+/** Open the search panel then click the first facet button. */
 async function openPanelAndFacet(page) {
-  // Open the search panel
+  // Click the trigger button (droppable/header mode — the panel lives here)
   await page.evaluate(() => {
-    const sb = document.querySelector('ol-search-bar');
-    sb?.shadowRoot?.querySelector('input')?.focus();
-    sb?.shadowRoot?.querySelector('input')?.click();
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('.trigger-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
   });
+
   await page.waitForFunction(() => {
-    const sb = document.querySelector('ol-search-bar');
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
     return sb?.shadowRoot?.querySelector('.panel') !== null;
   });
 
-  // Open the first facet dropdown
+  // Click the first facet button (Availability)
   await page.evaluate(() => {
-    const sb = document.querySelector('ol-search-bar');
-    sb?.shadowRoot?.querySelector('.pf-btn')?.dispatchEvent(
-      new MouseEvent('click', { bubbles: true, composed: true })
-    );
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('.pf-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
   });
 
-  // Wait for ol-facet-drop to appear
   await page.waitForFunction(() => {
-    const sb = document.querySelector('ol-search-bar');
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
     return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
   }, { timeout: 3000 });
 }
@@ -47,50 +54,46 @@ test.describe('facet dropdown dismissal (issue #21)', () => {
   test('clicking .panel-chips closes an open facet dropdown', async ({ page }) => {
     await openPanelAndFacet(page);
 
-    // Confirm facet-drop is open
-    const openBefore = await page.evaluate(() =>
-      document.querySelector('ol-search-bar')?.shadowRoot?.querySelector('ol-facet-drop') !== null
-    );
+    const openBefore = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+    });
     expect(openBefore).toBe(true);
 
     // Click panel-chips — inside ol-search-bar but outside ol-facet-drop
     await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
-      sb?.shadowRoot?.querySelector('.panel-chips')?.dispatchEvent(
-        new MouseEvent('click', { bubbles: true, composed: true })
-      );
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.panel-chips')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     });
 
-    // Facet-drop should be removed from the DOM
-    await page.waitForFunction(() =>
-      document.querySelector('ol-search-bar')?.shadowRoot?.querySelector('ol-facet-drop') === null,
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') === null;
+    }, { timeout: 2000 });
 
-    const gone = await page.evaluate(() =>
-      document.querySelector('ol-search-bar')?.shadowRoot?.querySelector('ol-facet-drop') === null
-    );
+    const gone = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') === null;
+    });
     expect(gone).toBe(true);
   });
 
   test('clicking inside ol-facet-drop keeps it open', async ({ page }) => {
     await openPanelAndFacet(page);
 
-    // Click the ol-facet-drop host itself — no interactive child triggered,
-    // but composed path includes OL-FACET-DROP so _onDoc guard preserves it
     await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
       const drop = sb?.shadowRoot?.querySelector('ol-facet-drop');
       drop?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     });
 
-    // Brief settle
     await page.waitForTimeout(200);
 
-    // ol-facet-drop must still be present
-    const stillOpen = await page.evaluate(() =>
-      document.querySelector('ol-search-bar')?.shadowRoot?.querySelector('ol-facet-drop') !== null
-    );
+    const stillOpen = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+    });
     expect(stillOpen).toBe(true);
   });
 });
@@ -104,33 +107,38 @@ test.describe('submit button (issue #22)', () => {
     await waitForCustomElements(page);
     await page.locator('ol-search-bar').waitFor({ state: 'attached' });
 
-    // Arm the listener before interacting
     await page.evaluate(() => {
       window.__olSearchFired = false;
       document.addEventListener('ol-search', () => { window.__olSearchFired = true; }, { once: true });
     });
 
-    // Focus input and set query value
+    // Open the panel, then type into the panel-input
     await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
-      const input = sb?.shadowRoot?.querySelector('input');
-      input?.focus();
-      input?.click();
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.trigger-btn')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('.panel-input') !== null;
+    });
+
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const input = sb?.shadowRoot?.querySelector('.panel-input');
       if (input) {
         input.value = 'frankenstein';
         input.dispatchEvent(new Event('input', { bubbles: true }));
       }
     });
 
-    // Click the submit button
+    // Click the submit button inside the panel
     await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
-      sb?.shadowRoot?.querySelector('.submit')?.dispatchEvent(
-        new MouseEvent('click', { bubbles: true, composed: true })
-      );
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.panel .submit')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     });
 
-    // Wait deterministically for the event rather than a fixed timeout
     await page.waitForFunction(() => window.__olSearchFired === true, { timeout: 2000 });
 
     const fired = await page.evaluate(() => window.__olSearchFired);

--- a/frontend/tests/mobile-facet-layout.spec.js
+++ b/frontend/tests/mobile-facet-layout.spec.js
@@ -151,6 +151,58 @@ test.describe('mobile overlay — Author facet layout stability', () => {
     await page.screenshot({ path: 'tests/screenshots/mobile-author-drop-visible.png' });
   });
 
+  test('first-half facets open left-aligned; second-half facets open right-aligned', async ({ page }) => {
+    await openMobileOverlay(page);
+
+    // Facet order: avail(0) lang(1) genre(2) | subject(3) author(4) sort(5)
+    // Mid = floor((6-1)/2) = 2, so indices 0-2 → left-aligned, 3-5 → right-aligned.
+    const leftFacets  = [FACET_IDX.avail, FACET_IDX.lang, FACET_IDX.genre];
+    const rightFacets = [FACET_IDX.subject, FACET_IDX.author, FACET_IDX.sort];
+
+    for (const idx of leftFacets) {
+      await clickFacetBtn(page, idx);
+      await page.waitForFunction(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+      }, { timeout: 2000 });
+
+      // ol-facet-drop must NOT have the [right] attribute
+      const hasRight = await page.evaluate(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop')?.hasAttribute('right') ?? null;
+      });
+      expect(hasRight).toBe(false);
+
+      // Close it before opening the next
+      await clickFacetBtn(page, idx);
+      await page.waitForFunction(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop') === null;
+      }, { timeout: 1000 });
+    }
+
+    for (const idx of rightFacets) {
+      await clickFacetBtn(page, idx);
+      await page.waitForFunction(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+      }, { timeout: 2000 });
+
+      // ol-facet-drop MUST have the [right] attribute
+      const hasRight = await page.evaluate(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop')?.hasAttribute('right') ?? null;
+      });
+      expect(hasRight).toBe(true);
+
+      await clickFacetBtn(page, idx);
+      await page.waitForFunction(() => {
+        const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+        return sb?.shadowRoot?.querySelector('ol-facet-drop') === null;
+      }, { timeout: 1000 });
+    }
+  });
+
   test('other facets remain visible and not displaced when Author is open', async ({ page }) => {
     await openMobileOverlay(page);
 

--- a/frontend/tests/mobile-facet-layout.spec.js
+++ b/frontend/tests/mobile-facet-layout.spec.js
@@ -1,0 +1,190 @@
+/**
+ * Regression tests for mobile overlay facet dropdown layout stability.
+ *
+ * Root cause: @media (max-width: 600px) sets overflow-x:auto on .pf-bar, which
+ * the CSS spec forces to also set overflow-y:auto, turning .pf-bar into a scroll
+ * container. When ol-facet-drop.firstUpdated() focuses its search input, the
+ * browser auto-scrolls .pf-bar to bring the input into view — scrolling all facet
+ * buttons off-screen (Availability disappears left). The Author facet triggers this
+ * most visibly because its search-inline input is focused on open.
+ *
+ * Fix: :host(.mobile-exp) .pf-bar { overflow: visible; flex-wrap: wrap; } with
+ * higher specificity (0,2,0 > 0,1,0) overrides the media block in overlay mode.
+ *
+ * NOTE: ol-search-bar lives inside ol-header's shadow DOM, not in the light DOM,
+ * so all evaluate() helpers traverse: document → ol-header.shadowRoot → ol-search-bar.
+ */
+
+import { test, expect } from '@playwright/test';
+
+const MOBILE = { width: 375, height: 812 };
+
+// Facet button order inside .pf-bar: avail(0) lang(1) genre(2) subject(3) author(4) sort(5) cog(6)
+const FACET_IDX = { avail: 0, lang: 1, genre: 2, subject: 3, author: 4, sort: 5 };
+
+async function waitForComponents(page) {
+  await page.waitForFunction(() =>
+    customElements.get('ol-search-bar') !== undefined &&
+    customElements.get('ol-header') !== undefined &&
+    customElements.get('ol-facet-drop') !== undefined
+  );
+}
+
+/** Finds ol-search-bar inside ol-header's shadow DOM and clicks its trigger button. */
+async function openMobileOverlay(page) {
+  await waitForComponents(page);
+  await page.evaluate(() => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('.trigger-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+  });
+  await page.waitForFunction(() => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    return sb?.classList.contains('mobile-exp') === true;
+  }, { timeout: 3000 });
+}
+
+/** Clicks the nth .pf-btn (0-indexed) inside ol-search-bar's shadow DOM. */
+async function clickFacetBtn(page, idx) {
+  await page.evaluate((i) => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    const btn = [...(sb?.shadowRoot?.querySelectorAll('.pf-btn') ?? [])][i];
+    btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+  }, idx);
+}
+
+/** Returns the BoundingClientRect (as plain object) of the nth .pf-btn, or null. */
+async function pfBtnRect(page, idx) {
+  return page.evaluate((i) => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    const btn = [...(sb?.shadowRoot?.querySelectorAll('.pf-btn') ?? [])][i];
+    const r = btn?.getBoundingClientRect();
+    return r ? { top: r.top, right: r.right, bottom: r.bottom, left: r.left, width: r.width, height: r.height } : null;
+  }, idx);
+}
+
+// ── Main regression suite ─────────────────────────────────────────────────────
+
+test.describe('mobile overlay — Author facet layout stability', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize(MOBILE);
+    await page.goto('/');
+  });
+
+  test('Availability button stays on-screen after Author dropdown opens', async ({ page }) => {
+    await openMobileOverlay(page);
+
+    // Baseline: Availability button must already be visible
+    const availBefore = await pfBtnRect(page, FACET_IDX.avail);
+    expect(availBefore).not.toBeNull();
+    expect(availBefore.top).toBeGreaterThanOrEqual(0);
+    expect(availBefore.height).toBeGreaterThan(0);
+
+    // Open Author facet
+    await clickFacetBtn(page, FACET_IDX.author);
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+    }, { timeout: 2000 });
+
+    // Allow focus + scroll events to fully settle
+    await page.waitForTimeout(300);
+
+    await page.screenshot({ path: 'tests/screenshots/mobile-author-facet-open.png' });
+
+    const availAfter = await pfBtnRect(page, FACET_IDX.avail);
+    expect(availAfter).not.toBeNull();
+
+    // Availability button must still be within the visible viewport
+    expect(availAfter.top).toBeGreaterThanOrEqual(0);
+    expect(availAfter.bottom).toBeGreaterThan(0);
+    expect(availAfter.bottom).toBeLessThanOrEqual(MOBILE.height);
+    expect(availAfter.height).toBeGreaterThan(0);
+
+    // Must not have shifted vertically — the Author dropdown opens below the bar
+    expect(Math.abs(availAfter.top - availBefore.top)).toBeLessThan(8);
+  });
+
+  test('.pf-bar is not a scroll container inside the mobile overlay', async ({ page }) => {
+    await openMobileOverlay(page);
+
+    const overflow = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const bar = sb?.shadowRoot?.querySelector('.pf-bar');
+      if (!bar) return null;
+      const cs = getComputedStyle(bar);
+      return { x: cs.overflowX, y: cs.overflowY };
+    });
+
+    expect(overflow).not.toBeNull();
+    // 'auto' or 'scroll' would create a scroll container that clips position:absolute children
+    expect(overflow.x).not.toBe('auto');
+    expect(overflow.x).not.toBe('scroll');
+    expect(overflow.y).not.toBe('auto');
+    expect(overflow.y).not.toBe('scroll');
+  });
+
+  test('ol-facet-drop for Author is not clipped — has meaningful visible height', async ({ page }) => {
+    await openMobileOverlay(page);
+    await clickFacetBtn(page, FACET_IDX.author);
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+    }, { timeout: 2000 });
+
+    await page.waitForTimeout(300);
+
+    const dropRect = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const drop = sb?.shadowRoot?.querySelector('ol-facet-drop');
+      const r = drop?.getBoundingClientRect();
+      return r ? { top: r.top, bottom: r.bottom, height: r.height } : null;
+    });
+
+    expect(dropRect).not.toBeNull();
+    // Dropdown must have real content height — if clipped, height would be ~0
+    expect(dropRect.height).toBeGreaterThan(50);
+    // Must be inside (or near) the viewport vertically
+    expect(dropRect.bottom).toBeGreaterThan(0);
+
+    await page.screenshot({ path: 'tests/screenshots/mobile-author-drop-visible.png' });
+  });
+
+  test('other facets remain visible and not displaced when Author is open', async ({ page }) => {
+    await openMobileOverlay(page);
+
+    // Capture all non-cog facet button rects before opening Author
+    const rectsBefore = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const btns = [...(sb?.shadowRoot?.querySelectorAll('.pf-btn') ?? [])].slice(0, 6);
+      return btns.map(b => {
+        const r = b.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom, left: r.left, height: r.height };
+      });
+    });
+
+    await clickFacetBtn(page, FACET_IDX.author);
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
+    }, { timeout: 2000 });
+    await page.waitForTimeout(300);
+
+    const rectsAfter = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const btns = [...(sb?.shadowRoot?.querySelectorAll('.pf-btn') ?? [])].slice(0, 6);
+      return btns.map(b => {
+        const r = b.getBoundingClientRect();
+        return { top: r.top, bottom: r.bottom, left: r.left, height: r.height };
+      });
+    });
+
+    // Every facet button must still be on-screen and must not have shifted vertically
+    for (let i = 0; i < rectsBefore.length; i++) {
+      expect(rectsAfter[i].height).toBeGreaterThan(0);        // not collapsed/clipped
+      expect(rectsAfter[i].top).toBeGreaterThanOrEqual(0);    // still on screen
+      expect(Math.abs(rectsAfter[i].top - rectsBefore[i].top)).toBeLessThan(8);  // no layout shift
+    }
+  });
+});

--- a/frontend/tests/mobile-overlay.spec.js
+++ b/frontend/tests/mobile-overlay.spec.js
@@ -1,3 +1,12 @@
+/**
+ * ol-search-bar mobile overlay tests (issue #23).
+ *
+ * ol-search-bar lives inside ol-header's shadow DOM, so all page.evaluate()
+ * helpers traverse: document → ol-header.shadowRoot → ol-search-bar.
+ * Playwright's page.locator() pierces shadow DOM automatically; native
+ * document.querySelector() does not.
+ */
+
 import { test, expect } from '@playwright/test';
 
 async function waitForSearchBar(page) {
@@ -5,13 +14,12 @@ async function waitForSearchBar(page) {
   await page.locator('ol-search-bar').waitFor({ state: 'attached' });
 }
 
-async function focusSearchInput(page) {
+/** Click the trigger button to open the search panel / mobile overlay. */
+async function openSearch(page) {
   await page.evaluate(() => {
-    const sb = document.querySelector('ol-search-bar');
-    sb?.shadowRoot?.querySelector('input')?.focus();
-    sb?.shadowRoot?.querySelector('input')?.dispatchEvent(
-      new MouseEvent('click', { bubbles: true, composed: true })
-    );
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('.trigger-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
   });
 }
 
@@ -23,17 +31,17 @@ test.describe('mobile full-screen overlay (issue #23)', () => {
     await page.goto('/');
     await waitForSearchBar(page);
 
-    await focusSearchInput(page);
+    await openSearch(page);
 
-    // Wait for the class to appear
-    await page.waitForFunction(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
 
-    const hasMobileExp = await page.evaluate(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
-    );
+    const hasMobileExp = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') ?? false;
+    });
     expect(hasMobileExp).toBe(true);
 
     await page.screenshot({
@@ -46,15 +54,15 @@ test.describe('mobile full-screen overlay (issue #23)', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
     await waitForSearchBar(page);
-    await focusSearchInput(page);
+    await openSearch(page);
 
-    await page.waitForFunction(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
 
     const { position, width, height } = await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
       const style = getComputedStyle(sb);
       const box = sb.getBoundingClientRect();
       return { position: style.position, width: box.width, height: box.height };
@@ -69,28 +77,28 @@ test.describe('mobile full-screen overlay (issue #23)', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
     await waitForSearchBar(page);
-    await focusSearchInput(page);
+    await openSearch(page);
 
-    await page.waitForFunction(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
 
-    // Click the back button inside the shadow DOM
     await page.evaluate(() => {
-      const sb = document.querySelector('ol-search-bar');
-      const btn = sb?.shadowRoot?.querySelector('.mob-back-btn');
-      btn?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.mob-back-btn')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
     });
 
-    await page.waitForFunction(() =>
-      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === false;
+    }, { timeout: 2000 });
 
-    const dismissed = await page.evaluate(() =>
-      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
-    );
+    const dismissed = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return !sb?.classList.contains('mobile-exp');
+    });
     expect(dismissed).toBe(true);
 
     await page.screenshot({
@@ -103,40 +111,42 @@ test.describe('mobile full-screen overlay (issue #23)', () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/');
     await waitForSearchBar(page);
-    await focusSearchInput(page);
+    await openSearch(page);
 
-    await page.waitForFunction(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
 
     await page.keyboard.press('Escape');
 
-    await page.waitForFunction(() =>
-      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp'),
-      { timeout: 2000 }
-    );
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === false;
+    }, { timeout: 2000 });
 
-    const dismissed = await page.evaluate(() =>
-      !document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
-    );
+    const dismissed = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return !sb?.classList.contains('mobile-exp');
+    });
     expect(dismissed).toBe(true);
   });
 });
 
 test.describe('desktop — no overlay regression', () => {
-  test('focusing search input on desktop does NOT add mobile-exp class', async ({ page }) => {
+  test('clicking search trigger on desktop does NOT add mobile-exp class', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
     await page.goto('/');
     await waitForSearchBar(page);
-    await focusSearchInput(page);
+    await openSearch(page);
 
-    // Give it time to settle — the class should NOT appear
+    // Give Lit time to update
     await page.waitForTimeout(300);
 
-    const hasMobileExp = await page.evaluate(() =>
-      document.querySelector('ol-search-bar')?.classList.contains('mobile-exp')
-    );
+    const hasMobileExp = await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') ?? false;
+    });
     expect(hasMobileExp).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Implements the GitHub/Hardcover-style trigger+overlay search pattern for `ol-search-bar`, plus a comprehensive round of bug fixes across multiple sessions.

### Architecture changes
- **Trigger+overlay pattern**: header input is now a dumb trigger button; the real search input lives inside the fixed overlay panel
- **`position:fixed` panel** anchored via CSS custom properties (`--ol-panel-top/right/left/width`) set by `_positionPanel()` in JS
- **3-breakpoint layout**: ≥900px right-aligned, 600–900px horizontally centered, ≤785px full-screen mobile overlay

### Features
- Full-screen mobile overlay at ≤785px (matches icon-only trigger breakpoint) — clicking the magnifying glass icon opens a viewport-filling search experience
- 785px icon-only trigger: collapses to magnifying glass + barcode icons, right-aligned toward login
- Panel repositions on resize (no longer closes); transitions correctly between desktop and mobile modes
- `_mobileExpanded` state drives a `mobile-exp` host class that applies the full-screen CSS overlay

### Bug fixes
- **Facet dropdowns clipping in mobile overlay**: `.panel` was `overflow-y:auto` (scroll container) which clips `ol-facet-drop`'s `position:absolute` dropdown — changed to `overflow:visible`; results use their own `max-height:40vh` scroll
- **Subject/Language filter state corruption**: Lit was recycling DOM nodes by index when the "Selected" section appeared, causing stale `.checked` state — fixed with `repeat()` directive (unique keys) in all multi-select lists
- **Trigger text causing header layout shift**: added `overflow:hidden; text-overflow:ellipsis` to `.trigger-btn`
- **Icon spacing**: `gap:6px` on `.panel-input-row` and narrow-trigger `.input-row`
- **Panel corner artifacts**: `border-radius:6.5px 6.5px 0 0` on `.panel-input-row`
- **Resize closes panel**: `_onWinResize` now repositions instead of closing
- **Two visible inputs at ≤600px**: `:host(.mobile-exp) .input-row { display:none }` hides the trigger row

## Test plan

- [ ] Open search at >900px — panel appears right-aligned, min 600px wide
- [ ] Open search at 600–900px — panel appears horizontally centered
- [ ] Open search at ≤785px — full-screen mobile overlay opens (no desktop panel)
- [ ] Resize browser while panel is open — panel repositions; crossing 785px transitions between modes
- [ ] Select Language: Spanish + French, switch to Genre, select Mystery, return to Language — French still selected
- [ ] Select Subject: Detectives — no other subject auto-checks
- [ ] Open facet dropdown (e.g. Genre) in mobile overlay — dropdown appears above content, not clipped
- [ ] Type long query in trigger — text truncates with ellipsis, header does not shift
- [ ] `npx vitest run` → 128/128 passing