### PR TITLE
refactor: consolidate panel close state into _closePanel() helper

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -100,10 +100,7 @@ export class OlSearchBar extends LitElement {
     this._onDoc = e => {
       const path = e.composedPath();
       if (!path.includes(this)) {
-        this._openFacet = null;
-        this._open = false;
-        this._acFocusIdx = -1;
-        this._mobileExpanded = false;
+        this._closePanel();
       } else if (this._openFacet !== null) {
         const inFacetDrop = path.some(el => el?.tagName === 'OL-FACET-DROP');
         const inFacetBtn  = path.some(el => el?.classList?.contains?.('pf-btn'));
@@ -200,6 +197,14 @@ export class OlSearchBar extends LitElement {
     this._openFacet = null;
   }
 
+  // Single close path: keeps _open, _mobileExpanded, _openFacet, _acFocusIdx in sync.
+  _closePanel() {
+    this._open          = false;
+    this._mobileExpanded = false;
+    this._openFacet     = null;
+    this._acFocusIdx    = -1;
+  }
+
   _onInput(e) {
     this._q = e.target.value;
     if (this.showFacets) this._open = true;
@@ -256,8 +261,7 @@ export class OlSearchBar extends LitElement {
 
   _onKeyDown(e) {
     if (e.key === 'Escape') {
-      this._open = false; this._openFacet = null; this._acFocusIdx = -1;
-      this._mobileExpanded = false; return;
+      this._closePanel(); return;
     }
     // Arrow navigation through autocomplete results.
     if (this._open && this._suggestions.length > 0) {
@@ -782,7 +786,7 @@ export class OlSearchBar extends LitElement {
                    href="${this.siteBase}${linkKey}"
                    target="_blank" rel="noopener"
                    role="option"
-                   @click=${() => { this._open = false; this._mobileExpanded = false; }}>
+                   @click=${() => this._closePanel()}>
                   ${cover
                     ? html`<img class="ac-cover" src=${cover} alt="" loading="lazy">`
                     : html`<div class="ac-blank">📖</div>`}
@@ -806,7 +810,7 @@ export class OlSearchBar extends LitElement {
            target="_blank" rel="noopener"
            @click=${e => e.stopPropagation()}>+ Add Book</a>
         <button class="ac-see-all" @click=${() => {
-          this._open = false; this._mobileExpanded = false;
+          this._closePanel();
           if (!q && !this._hasActiveFilters()) return;
           this.dispatchEvent(new CustomEvent('ol-search', {
             detail: { q, filters: this._localFilters }, bubbles: true, composed: true,
@@ -895,7 +899,7 @@ export class OlSearchBar extends LitElement {
             ${this._mobileExpanded ? html`
               <div class="mob-back-bar">
                 <button class="mob-back-btn" aria-label="Close search"
-                        @click=${e => { e.stopPropagation(); this._mobileExpanded = false; this._open = false; this._openFacet = null; this._acFocusIdx = -1; }}>
+                        @click=${e => { e.stopPropagation(); this._closePanel(); }}>
                   ← Back
                 </button>
               </div>` : nothing}

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -74,9 +74,9 @@ describe('ol-search-bar mobile overlay JS contract', () => {
     expect(fn).toMatch(/_mobileExpanded\s*=\s*true/);
   });
 
-  it('clears _mobileExpanded in _onKeyDown Escape path', () => {
+  it('calls _closePanel() in _onKeyDown Escape path', () => {
     const escapeBlock = src.slice(src.indexOf("key === 'Escape'"), src.indexOf("key === 'Escape'") + 200);
-    expect(escapeBlock).toMatch(/_mobileExpanded\s*=\s*false/);
+    expect(escapeBlock).toMatch(/_closePanel\(\)/);
   });
 
   it('toggles mobile-exp class on :host via updated()', () => {


### PR DESCRIPTION
## Summary

- Extracts a `_closePanel()` method that atomically resets all four close-state flags: `_open`, `_mobileExpanded`, `_openFacet`, `_acFocusIdx`
- Replaces five inline close-state scatterings (outside-click handler, Escape keydown, ac-row click, see-all click, back button)
- Fixes a pre-existing bug: the autocomplete row click and "see all results" paths were missing `_openFacet = null` and `_acFocusIdx = -1` resets — a facet left open before clicking a result would reappear on the next panel open

## Why a dedicated method rather than just fixing the two missing resets

Every time someone adds a new close path (future keyboard shortcut, swipe gesture, focus-out) they have to know about all four flags. `_closePanel()` makes the contract explicit and leaves a single place to add teardown if the panel gains more state later.

## Test plan

- [ ] 167 unit tests pass (`npm test`)
- [ ] Lint clean (`npm run lint`)
- [ ] Manually verify: open panel, open a facet dropdown, click an autocomplete result — facet should not reopen on next panel open
- [ ] Manually verify: Escape, outside click, back button all dismiss panel fully on mobile and desktop