### PR TITLE
docs: add FilterState typedef and annotate filter-passing functions

### DIFF
--- a/frontend/src/utils/filters.js
+++ b/frontend/src/utils/filters.js
@@ -122,13 +122,20 @@ export const POPULAR_AUTHORS = [
 
 /**
  * @typedef {Object} FilterState
- * @property {string}   sort           - '' | 'new' | 'old' | 'rating desc' | 'readinglog desc' | 'title'
- * @property {string}   availability   - '' | 'readable' | 'borrowable' | 'open'
- * @property {string}   fictionFilter  - '' | 'fiction' | 'nonfiction'
- * @property {string[]} languages      - ISO 639-2/B codes e.g. ['eng', 'spa']
- * @property {string[]} genres         - values from GENRE_OPTIONS e.g. ['mystery']
- * @property {string[]} authors        - free-text author names
- * @property {string[]} subjects       - free-text subject names
+ * @property {''|'new'|'old'|'rating desc'|'readinglog desc'|'title'} sort
+ *   Sort value from SORT_OPTIONS.
+ * @property {''|'readable'|'borrowable'|'open'} availability
+ *   Availability filter from AVAILABILITY_OPTIONS.
+ * @property {''|'fiction'|'nonfiction'} fictionFilter
+ *   Fiction/nonfiction filter.
+ * @property {string[]} [languages]
+ *   ISO 639-2/B codes e.g. ['eng', 'spa'].
+ * @property {string[]} [genres]
+ *   Values from GENRE_OPTIONS e.g. ['mystery'].
+ * @property {string[]} [authors]
+ *   Free-text author names.
+ * @property {string[]} [subjects]
+ *   Free-text subject names.
  */
 
 // DEFAULT_FILTERS is the canonical name — "EMPTY" was a misnomer because
@@ -184,7 +191,8 @@ export function shufflePick(arr, n) {
 
 /**
  * Derive the chip array from a filter state object.
- * Each chip label includes a human-readable "type: value" prefix.
+ * Chip labels are human-readable; language/genre/author/subject labels include a
+ * "type: value" prefix, while availability and fiction use plain descriptive labels.
  * Ordering: availability → fictionFilter → language → genre → author → subject
  * @param {FilterState} filters
  * @returns {{ type: string, label: string, value: string|null }[]}

--- a/frontend/src/utils/filters.js
+++ b/frontend/src/utils/filters.js
@@ -120,6 +120,17 @@ export const POPULAR_AUTHORS = [
   'Chimamanda Ngozi Adichie', 'Kazuo Ishiguro', 'Salman Rushdie', 'Milan Kundera',
 ];
 
+/**
+ * @typedef {Object} FilterState
+ * @property {string}   sort           - '' | 'new' | 'old' | 'rating desc' | 'readinglog desc' | 'title'
+ * @property {string}   availability   - '' | 'readable' | 'borrowable' | 'open'
+ * @property {string}   fictionFilter  - '' | 'fiction' | 'nonfiction'
+ * @property {string[]} languages      - ISO 639-2/B codes e.g. ['eng', 'spa']
+ * @property {string[]} genres         - values from GENRE_OPTIONS e.g. ['mystery']
+ * @property {string[]} authors        - free-text author names
+ * @property {string[]} subjects       - free-text subject names
+ */
+
 // DEFAULT_FILTERS is the canonical name — "EMPTY" was a misnomer because
 // availability defaults to 'readable', not to a truly empty state.
 export const DEFAULT_FILTERS = {
@@ -175,6 +186,8 @@ export function shufflePick(arr, n) {
  * Derive the chip array from a filter state object.
  * Each chip label includes a human-readable "type: value" prefix.
  * Ordering: availability → fictionFilter → language → genre → author → subject
+ * @param {FilterState} filters
+ * @returns {{ type: string, label: string, value: string|null }[]}
  */
 export function buildChips(filters) {
   const chips = [];
@@ -223,6 +236,11 @@ export function buildChips(filters) {
  * Build URLSearchParams for a search request.
  * Multi-value arrays (languages, genres, authors, subjects) are each appended
  * as repeated params; the backend ORs them together within each facet.
+ * @param {string}      q
+ * @param {FilterState} filters
+ * @param {number}      page
+ * @param {number}      limit
+ * @returns {URLSearchParams}
  */
 export function buildSearchParams(q, filters, page, limit) {
   const p = new URLSearchParams();

--- a/frontend/src/utils/filters.test.js
+++ b/frontend/src/utils/filters.test.js
@@ -468,4 +468,14 @@ describe('FilterState typedef', () => {
     const matches = [...filtersSrc.matchAll(/@param\s*\{FilterState\}/g)];
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
+
+  it('FilterState uses literal-union types for sort, availability, and fictionFilter', () => {
+    const typedef = filtersSrc.slice(
+      filtersSrc.indexOf('@typedef {Object} FilterState'),
+      filtersSrc.indexOf('@typedef {Object} FilterState') + 600,
+    );
+    expect(typedef).toMatch(/'new'.*'old'|'old'.*'new'/);   // sort has at least two literals
+    expect(typedef).toMatch(/'readable'/);                  // availability literal
+    expect(typedef).toMatch(/'fiction'.*'nonfiction'|'nonfiction'.*'fiction'/); // fictionFilter literals
+  });
 });

--- a/frontend/src/utils/filters.test.js
+++ b/frontend/src/utils/filters.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
 import {
   toggleArrayValue,
   shufflePick,
@@ -445,5 +446,26 @@ describe('DEFAULT_FILTERS', () => {
 
   it('EMPTY_FILTERS is still exported so existing import sites do not break', () => {
     expect(EMPTY_FILTERS).toBeDefined();
+  });
+});
+
+// ── FilterState typedef static-analysis ──────────────────────────────────────
+
+const filtersSrc = readFileSync(new URL('./filters.js', import.meta.url), 'utf8');
+
+describe('FilterState typedef', () => {
+  it('@typedef {Object} FilterState is declared in filters.js', () => {
+    expect(filtersSrc).toMatch(/@typedef\s*\{Object\}\s*FilterState/);
+  });
+
+  it('all seven filter fields are documented with @property', () => {
+    for (const field of ['sort', 'availability', 'fictionFilter', 'languages', 'genres', 'authors', 'subjects']) {
+      expect(filtersSrc).toMatch(new RegExp(`@property.*${field}`));
+    }
+  });
+
+  it('buildChips and buildSearchParams each have a @param {FilterState} annotation (2 total)', () => {
+    const matches = [...filtersSrc.matchAll(/@param\s*\{FilterState\}/g)];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 });


### PR DESCRIPTION
Closes #35

## What

Adds `@typedef {Object} FilterState` to `utils/filters.js` with a `@property` line for each of the seven filter fields and their accepted value ranges. Annotates `buildChips` and `buildSearchParams` with `@param {FilterState}` and `@returns`.

## Why

The filter object is the primary data structure passed between `ol-search-bar`, `ol-search-page`, and the utils layer. Without a typedef, editors give no autocomplete or type errors when callers pass the wrong shape. New contributors have to read all consumers to discover what keys exist.

## Verified by

Four new static-analysis tests in `filters.test.js`:
- `@typedef {Object} FilterState` exists in the source
- All 7 fields have `@property` entries
- At least 2 `@param {FilterState}` annotations exist (buildChips + buildSearchParams)

No behavioral changes — 170 tests pass, lint clean.