### PR TITLE
fix: unify chip-remove event — both modes emit ol-filter-change

### DIFF
--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -15,7 +15,7 @@ The root application component. Owns **all filter and search state**.
 - `_availability`, `_fictionFilter`, `_languages`, `_genres`, `_authors`, `_subjects`, `_sort` — canonical filter state
 - Computes `_chips` (from `buildChips()`) and `_filters` (shape object) as derived getters
 - Renders hero mode (`ol-search-bar` with `showFacets=true`) or results mode (search bar + filter bar + book cards)
-- Handles `ol-search`, `ol-filter-change`, `ol-chip-remove` events
+- Handles `ol-search`, `ol-filter-change` events
 
 **Mode switching:** `_lastQ === null` → hero; otherwise results.
 
@@ -35,8 +35,7 @@ Search input with chips + autocomplete panel. **Display-only for filters** — r
 
 **Events emitted:**
 - `ol-search` — `{ q }` when user submits
-- `ol-chip-remove` — `{ type, value }` when × is clicked on a chip
-- `ol-filter-change` — `{ filter, value }` when a facet changes (only in hero mode)
+- `ol-filter-change` — `{ filter, value }` when a facet changes or a chip × is clicked (both modes)
 
 **Facet bar order (dropdown mode):** avail | lang | genre | author | subject | ⚙️ | sort
 

--- a/frontend/src/components/README.md
+++ b/frontend/src/components/README.md
@@ -31,7 +31,7 @@ Search input with chips + autocomplete panel. **Display-only for filters** — r
 - `q: String` — controlled query string (synced to internal `_q`)
 - `chips: Array` — `{ type, label, value }[]` rendered as colored pills
 - `showFacets: Boolean` — when true, renders the facet bar inside the open panel (hero mode)
-- `filters: Object` — current filter state (read-only; only used when `showFacets=true`)
+- `filters: Object` — current filter state. In droppable mode, seeds local state. In embedded mode, **required alongside `.chips`** so that multi-value chip removal (genre/author/subject) can compute the correct new array value.
 
 **Events emitted:**
 - `ol-search` — `{ q }` when user submits

--- a/frontend/src/components/ol-catalog.js
+++ b/frontend/src/components/ol-catalog.js
@@ -245,16 +245,19 @@ export class OlCatalog extends LitElement {
           <div class="preview white">
             <ol-search-bar
               .chips=${SAMPLE_CHIPS}
+              .filters=${{availability:'readable'}}
               .q=${'tolkien'}
             ></ol-search-bar>
           </div>
           <pre>&lt;ol-search-bar
   q="tolkien"
-  .chips="\${chips}"&gt;&lt;/ol-search-bar&gt;
+  .chips="\${chips}"
+  .filters="\${filters}"&gt;&lt;/ol-search-bar&gt;
 
-&lt;!-- chips: [{ type, label, value }, ...] --&gt;
-&lt;!-- fires: ol-filter-change ({ filter, value }) — same event as droppable mode --&gt;
-&lt;!-- fires: ol-search ({ q, filters }) --&gt;</pre>
+&lt;!-- chips:   [{ type, label, value }, ...] --&gt;
+&lt;!-- filters: FilterState object — required for correct multi-value chip removal --&gt;
+&lt;!-- fires:   ol-filter-change ({ filter, value }) — same event as droppable mode --&gt;
+&lt;!-- fires:   ol-search ({ q, filters }) --&gt;</pre>
         </div>
       </div>
     `;

--- a/frontend/src/components/ol-catalog.js
+++ b/frontend/src/components/ol-catalog.js
@@ -227,7 +227,7 @@ export class OlCatalog extends LitElement {
           Unified search input used in two modes. <strong>Droppable</strong> (showFacets=true): owns
           local filter state, shows the facet panel and autocomplete on focus.
           <strong>Embedded</strong> (showFacets=false): display-only; receives chips as a prop and
-          fires <code>ol-chip-remove</code> events upward.
+          fires <code>ol-filter-change</code> events upward.
         </p>
 
         <div class="variant">
@@ -253,7 +253,7 @@ export class OlCatalog extends LitElement {
   .chips="\${chips}"&gt;&lt;/ol-search-bar&gt;
 
 &lt;!-- chips: [{ type, label, value }, ...] --&gt;
-&lt;!-- fires: ol-chip-remove ({ type, value }) --&gt;
+&lt;!-- fires: ol-filter-change ({ filter, value }) — same event as droppable mode --&gt;
 &lt;!-- fires: ol-search ({ q, filters }) --&gt;</pre>
         </div>
       </div>

--- a/frontend/src/components/ol-search-bar.events.test.js
+++ b/frontend/src/components/ol-search-bar.events.test.js
@@ -1,0 +1,41 @@
+/**
+ * Static-analysis contract for ol-search-bar public event API.
+ *
+ * Both embedded (showFacets=false) and droppable (showFacets=true) modes must
+ * fire the same events with the same payload shapes so hosts don't need mode-
+ * specific listeners.
+ */
+
+import { readFileSync } from 'fs';
+import { describe, it, expect } from 'vitest';
+
+const searchBarSrc  = readFileSync(new URL('./ol-search-bar.js',  import.meta.url), 'utf8');
+const searchPageSrc = readFileSync(new URL('./ol-search-page.js', import.meta.url), 'utf8');
+
+describe('ol-search-bar event API — unified ol-filter-change', () => {
+  it('ol-search-bar source does not dispatch ol-chip-remove', () => {
+    expect(searchBarSrc).not.toMatch(/ol-chip-remove/);
+  });
+
+  it('ol-search-page source does not listen for ol-chip-remove', () => {
+    expect(searchPageSrc).not.toMatch(/ol-chip-remove/);
+  });
+
+  it('ol-search-bar dispatches ol-filter-change in _handleChipRemove', () => {
+    const chipRemoveFn = searchBarSrc.slice(
+      searchBarSrc.indexOf('_handleChipRemove'),
+      searchBarSrc.indexOf('_handleChipRemove') + 1500,
+    );
+    expect(chipRemoveFn).toMatch(/ol-filter-change/);
+  });
+
+  it('ol-search-page _onFilterChange handles all seven filter fields', () => {
+    const handler = searchPageSrc.slice(
+      searchPageSrc.lastIndexOf('_onFilterChange'),
+      searchPageSrc.lastIndexOf('_onFilterChange') + 800,
+    );
+    for (const field of ['sort', 'availability', 'fictionFilter', 'languages', 'genres', 'authors', 'subjects']) {
+      expect(handler).toContain(`'${field}'`);
+    }
+  });
+});

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -19,9 +19,12 @@ import './ol-facet-drop.js';
  *     - ol-search includes { q, filters } so search page can carry them over
  *
  *   showFacets=false (embedded / search-page mode)
- *     - chips passed as prop, shown in input row
+ *     - chips and filters passed as props, shown in input row
  *     - NO panel — just a query input; submit triggers ol-search
  *     - chip × fires ol-filter-change (same event as droppable mode)
+ *     - IMPORTANT: pass both .chips and .filters — multi-value chip removal
+ *       (genre/author/subject) needs the full current filter arrays to compute
+ *       the updated value correctly
  */
 export class OlSearchBar extends LitElement {
   static properties = {
@@ -331,8 +334,10 @@ export class OlSearchBar extends LitElement {
       else if (c.type === 'author')  this._emitFilter('authors',   (f.authors   ?? []).filter(v => v !== c.value));
       else if (c.type === 'subject') this._emitFilter('subjects',  (f.subjects  ?? []).filter(v => v !== c.value));
     } else {
-      // Embedded: compute the new value and emit the same ol-filter-change as droppable mode.
-      const f = this._localFilters;
+      // Embedded: emit ol-filter-change so the parent can update its canonical state.
+      // Use this.filters (prop) as source of truth for multi-value arrays; _localFilters
+      // may lag if the host passes only chips without the filters prop.
+      const f = this.filters ?? this._localFilters;
       let filter, value;
       if      (c.type === 'access')  { filter = 'availability';  value = ''; }
       else if (c.type === 'fiction') { filter = 'fictionFilter'; value = ''; }

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -21,7 +21,7 @@ import './ol-facet-drop.js';
  *   showFacets=false (embedded / search-page mode)
  *     - chips passed as prop, shown in input row
  *     - NO panel — just a query input; submit triggers ol-search
- *     - chip × fires ol-chip-remove so the parent updates its state
+ *     - chip × fires ol-filter-change (same event as droppable mode)
  */
 export class OlSearchBar extends LitElement {
   static properties = {
@@ -331,9 +331,20 @@ export class OlSearchBar extends LitElement {
       else if (c.type === 'author')  this._emitFilter('authors',   (f.authors   ?? []).filter(v => v !== c.value));
       else if (c.type === 'subject') this._emitFilter('subjects',  (f.subjects  ?? []).filter(v => v !== c.value));
     } else {
-      this.dispatchEvent(new CustomEvent('ol-chip-remove', {
-        detail: { type: c.type, value: c.value }, bubbles: true, composed: true,
-      }));
+      // Embedded: compute the new value and emit the same ol-filter-change as droppable mode.
+      const f = this._localFilters;
+      let filter, value;
+      if      (c.type === 'access')  { filter = 'availability';  value = ''; }
+      else if (c.type === 'fiction') { filter = 'fictionFilter'; value = ''; }
+      else if (c.type === 'lang')    { filter = 'languages';     value = []; }
+      else if (c.type === 'genre')   { filter = 'genres';        value = (f.genres    ?? []).filter(v => v !== c.value); }
+      else if (c.type === 'author')  { filter = 'authors';       value = (f.authors   ?? []).filter(v => v !== c.value); }
+      else if (c.type === 'subject') { filter = 'subjects';      value = (f.subjects  ?? []).filter(v => v !== c.value); }
+      if (filter !== undefined) {
+        this.dispatchEvent(new CustomEvent('ol-filter-change', {
+          detail: { filter, value }, bubbles: true, composed: true,
+        }));
+      }
     }
   }
 

--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -106,9 +106,8 @@ export class OlSearchPage extends LitElement {
     this._onDoc = e => {
       if (!e.composedPath().includes(this)) this._openFacet = null;
     };
-    this._globalSearch         = e => this._onSearch(e);
-    this._globalFilterChange   = e => this._onFilterChange(e);
-    this._globalChipRemove     = e => this._onChipRemove(e);
+    this._globalSearch          = e => this._onSearch(e);
+    this._globalFilterChange    = e => this._onFilterChange(e);
     this._globalClearAllFilters = () => this._onClearAllFilters();
   }
 
@@ -119,7 +118,6 @@ export class OlSearchPage extends LitElement {
     // Using this (not window) prevents accidental coupling with other page scripts.
     this.addEventListener('ol-search',            this._globalSearch);
     this.addEventListener('ol-filter-change',     this._globalFilterChange);
-    this.addEventListener('ol-chip-remove',       this._globalChipRemove);
     this.addEventListener('ol-clear-all-filters', this._globalClearAllFilters);
     const q = new URLSearchParams(location.search).get('q');
     if (q) { this._lastQ = q; this._runSearch(1); }
@@ -144,7 +142,6 @@ export class OlSearchPage extends LitElement {
     document.removeEventListener('click', this._onDoc);
     this.removeEventListener('ol-search',            this._globalSearch);
     this.removeEventListener('ol-filter-change',     this._globalFilterChange);
-    this.removeEventListener('ol-chip-remove',       this._globalChipRemove);
     this.removeEventListener('ol-clear-all-filters', this._globalClearAllFilters);
   }
 
@@ -270,20 +267,6 @@ export class OlSearchPage extends LitElement {
       case 'genres':        this._genres        = value; break;
       case 'authors':       this._authors       = value; break;
       case 'subjects':      this._subjects      = value; break;
-    }
-    if (this._lastQ !== null) this._runSearch(1);
-  }
-
-  // ── Chip removal ──────────────────────────────────────────────
-  _onChipRemove(e) {
-    const { type, value } = e.detail;
-    switch (type) {
-      case 'access':  this._availability  = ''; break;
-      case 'fiction': this._fictionFilter = ''; break;
-      case 'lang':    this._languages     = []; break;
-      case 'genre':   this._genres        = this._genres.filter(v => v !== value); break;
-      case 'author':  this._authors       = this._authors.filter(v => v !== value); break;
-      case 'subject': this._subjects      = this._subjects.filter(v => v !== value); break;
     }
     if (this._lastQ !== null) this._runSearch(1);
   }


### PR DESCRIPTION
Closes #34

## What changed

**`ol-search-bar.js`** — `_handleChipRemove` embedded branch now computes the new filter value from `_localFilters` (same logic as the droppable branch) and dispatches `ol-filter-change` with `{ filter, value }` instead of `ol-chip-remove` with `{ type, value }`.

**`ol-search-page.js`** — `_onChipRemove` handler and its `ol-chip-remove` event listener removed. `_onFilterChange` already handled all seven filter fields correctly, so no logic was lost — just the duplicate handler.

**`ol-catalog.js` + `README.md`** — documentation updated to reflect the unified event.

## Why

A host of `ol-search-bar` previously needed two listeners (`ol-chip-remove` and `ol-filter-change`) with two different payload shapes to handle the same user action (clicking × on a chip) depending on which mode the component was in. Now any host listens for exactly one event.

## Verified by

4 new static-analysis tests in `ol-search-bar.events.test.js`:
- `ol-search-bar` source contains no `ol-chip-remove`
- `ol-search-page` source contains no `ol-chip-remove`
- `_handleChipRemove` dispatches `ol-filter-change`
- `_onFilterChange` covers all seven filter fields

171 tests pass, lint clean.