### PR TITLE
feat: show error message in autocomplete panel on search API failure

### DIFF
--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -48,6 +48,7 @@ export class OlSearchBar extends LitElement {
     _facetsLoading:    { state: true },
     _acFocusIdx:       { state: true },  // keyboard-focused autocomplete result index
     _mobileExpanded:   { state: true },  // full-screen overlay active on narrow viewport
+    _acError:          { state: true },  // true when autocomplete fetch fails (non-abort)
   };
 
   constructor() {
@@ -65,6 +66,7 @@ export class OlSearchBar extends LitElement {
     this._open          = false;
     this._loading       = false;
     this._total         = 0;
+    this._acError       = false;
     this._timer         = null;
     this._localFilters  = { ...EMPTY_FILTERS };
 
@@ -218,6 +220,7 @@ export class OlSearchBar extends LitElement {
     this._acAbort?.abort();
     this._acAbort = new AbortController();
     const { signal } = this._acAbort;
+    this._acError = false;
 
     const q = this._q.trim();
     const f = this._localFilters;
@@ -237,6 +240,7 @@ export class OlSearchBar extends LitElement {
     } catch (err) {
       if (err.name !== 'AbortError') {
         this._suggestions = []; this._total = 0; this._acFocusIdx = -1;
+        this._acError = true;
       }
     } finally {
       if (!signal.aborted) this._loading = false;
@@ -566,6 +570,10 @@ export class OlSearchBar extends LitElement {
     .ac-spin, .ac-hint-msg, .ac-empty {
       padding:16px; text-align:center; font-size:13px; color:hsl(0,0%,55%);
     }
+    .ac-error {
+      padding:16px; text-align:center; font-size:13px;
+      color:hsl(0,72%,40%); background:hsl(0,72%,97%);
+    }
     .ac-row {
       display:flex; align-items:center; gap:12px; padding:10px 14px;
       text-decoration:none; border-bottom:1px solid hsl(0,0%,94%);
@@ -759,6 +767,7 @@ export class OlSearchBar extends LitElement {
   _renderResults(q) {
     const showResults = q.length >= 2 || this._hasActiveFilters();
     if (this._loading) return html`<div class="ac-spin" role="status" aria-live="polite">Searching…</div>`;
+    if (this._acError) return html`<div class="ac-error" role="alert">Search is unavailable — check your connection and try again.</div>`;
     if (!showResults)  return html`<div class="ac-hint-msg" aria-live="polite">Start typing to search, or pick a filter above…</div>`;
     return html`
       <div class="ac-scroll" id="ac-listbox" role="listbox" aria-label="Search suggestions">

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -208,7 +208,8 @@ export class OlSearchBar extends LitElement {
     clearTimeout(this._timer);
     if (this._q.trim().length < 2 && !this._hasActiveFilters()) {
       this._suggestions = [];
-      this._loading = false;
+      this._acError     = false;
+      this._loading     = false;
       return;
     }
     this._loading = true;
@@ -252,6 +253,7 @@ export class OlSearchBar extends LitElement {
     clearTimeout(this._timer);
     this._q           = '';
     this._suggestions = [];
+    this._acError     = false;
     this._total       = 0;
     this._acFocusIdx  = -1;
     this._loading     = false;

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -164,12 +164,12 @@ describe('ol-search-bar autocomplete error state', () => {
   });
 
   it('sets _acError = true on non-abort fetch failure', () => {
-    const fetchFn = src.slice(src.indexOf('_fetchAutocomplete'), src.indexOf('_fetchAutocomplete') + 1500);
+    const fetchFn = src.slice(src.indexOf('async _fetchAutocomplete()'), src.indexOf('async _fetchAutocomplete()') + 1500);
     expect(fetchFn).toMatch(/_acError\s*=\s*true/);
   });
 
   it('resets _acError = false at the start of each fetch', () => {
-    const fetchFn = src.slice(src.indexOf('_fetchAutocomplete'), src.indexOf('_fetchAutocomplete') + 1500);
+    const fetchFn = src.slice(src.indexOf('async _fetchAutocomplete()'), src.indexOf('async _fetchAutocomplete()') + 1500);
     expect(fetchFn).toMatch(/_acError\s*=\s*false/);
   });
 
@@ -181,5 +181,15 @@ describe('ol-search-bar autocomplete error state', () => {
 
   it('.ac-error CSS rule exists in component styles', () => {
     expect(src).toMatch(/\.ac-error\s*\{/);
+  });
+
+  it('_onInput early-return path clears _acError so stale error does not persist', () => {
+    const fn = src.slice(src.indexOf('_onInput(e)'), src.indexOf('_onInput(e)') + 400);
+    expect(fn).toMatch(/_acError\s*=\s*false/);
+  });
+
+  it('_clearInput clears _acError so stale error does not persist', () => {
+    const fn = src.slice(src.indexOf('_clearInput()'), src.indexOf('_clearInput()') + 300);
+    expect(fn).toMatch(/_acError\s*=\s*false/);
   });
 });

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -151,3 +151,35 @@ describe('ol-search-bar panel overlay — mobile overlay not broken', () => {
     expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.input-row[^}]*display\s*:\s*none/);
   });
 });
+
+// ── Autocomplete error state contract ─────────────────────────────────────────
+
+describe('ol-search-bar autocomplete error state', () => {
+  it('declares _acError as a reactive state property', () => {
+    expect(src).toMatch(/_acError\s*:\s*\{[^}]*state\s*:\s*true/);
+  });
+
+  it('initialises _acError to false in constructor', () => {
+    expect(src).toMatch(/this\._acError\s*=\s*false/);
+  });
+
+  it('sets _acError = true on non-abort fetch failure', () => {
+    const fetchFn = src.slice(src.indexOf('_fetchAutocomplete'), src.indexOf('_fetchAutocomplete') + 1500);
+    expect(fetchFn).toMatch(/_acError\s*=\s*true/);
+  });
+
+  it('resets _acError = false at the start of each fetch', () => {
+    const fetchFn = src.slice(src.indexOf('_fetchAutocomplete'), src.indexOf('_fetchAutocomplete') + 1500);
+    expect(fetchFn).toMatch(/_acError\s*=\s*false/);
+  });
+
+  it('_renderResults renders a .ac-error element when _acError is true', () => {
+    const renderFn = src.slice(src.indexOf('_renderResults(q)'), src.indexOf('_renderResults(q)') + 400);
+    expect(renderFn).toMatch(/ac-error/);
+    expect(renderFn).toMatch(/_acError/);
+  });
+
+  it('.ac-error CSS rule exists in component styles', () => {
+    expect(src).toMatch(/\.ac-error\s*\{/);
+  });
+});


### PR DESCRIPTION
Closes #36

## Problem

A network failure or 500 during `_fetchAutocomplete` previously cleared `_suggestions` and silently rendered nothing. The open panel looked identical to "type more to search" — no way for users to know search was broken.

## Changes

- `_acError: { state: true }` added to properties, initialised `false`
- `_fetchAutocomplete` resets `_acError = false` at the start of each attempt; sets `_acError = true` on any non-abort exception
- `_renderResults` checks `_acError` before the hint/results branches → returns a `role="alert"` error div
- `.ac-error` CSS: muted red text on a light red background, same padding as `.ac-hint-msg`

## Done checklist

- [x] `_acError` declared as reactive state
- [x] `_acError = false` reset at start of every fetch
- [x] `_acError = true` set on non-abort errors
- [x] `_renderResults` renders `.ac-error` with `role="alert"` when true
- [x] `.ac-error` CSS rule in component styles
- [x] 6 static-analysis tests verify the full contract
- [x] 173 tests pass, lint clean