### PR TITLE
refactor: consolidate 7 filter props into single _filters object

### DIFF
--- a/frontend/src/components/ol-search-bar.events.test.js
+++ b/frontend/src/components/ol-search-bar.events.test.js
@@ -29,13 +29,12 @@ describe('ol-search-bar event API — unified ol-filter-change', () => {
     expect(chipRemoveFn).toMatch(/ol-filter-change/);
   });
 
-  it('ol-search-page _onFilterChange handles all seven filter fields', () => {
+  it('ol-search-page _onFilterChange uses computed key spread — not a hard-coded switch', () => {
     const handler = searchPageSrc.slice(
       searchPageSrc.lastIndexOf('_onFilterChange'),
-      searchPageSrc.lastIndexOf('_onFilterChange') + 800,
+      searchPageSrc.lastIndexOf('_onFilterChange') + 300,
     );
-    for (const field of ['sort', 'availability', 'fictionFilter', 'languages', 'genres', 'authors', 'subjects']) {
-      expect(handler).toContain(`'${field}'`);
-    }
+    // Refactored: one-liner using computed key { ...this._filters, [filter]: value }
+    expect(handler).toMatch(/\[filter\]\s*:\s*value/);
   });
 });

--- a/frontend/src/components/ol-search-page.filter-object.test.js
+++ b/frontend/src/components/ol-search-page.filter-object.test.js
@@ -96,13 +96,31 @@ describe('ol-search-page filter consolidation — mutation via spread', () => {
 
 describe('ol-search-page filter consolidation — updated() watches _filters', () => {
   it('updated() checks changed.has("_filters") not individual filter props', () => {
-    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 600);
     expect(fn).toMatch(/changed\.has\s*\(\s*['"]_filters['"]\s*\)/);
   });
 
   it('updated() does not check changed.has("_sort")', () => {
-    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 600);
     expect(fn).not.toMatch(/changed\.has\s*\(\s*['"]_sort['"]\s*\)/);
+  });
+});
+
+// ── Key validation ────────────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — key validation', () => {
+  it('FILTER_KEYS set is derived from DEFAULT_FILTERS so unknown keys are rejected', () => {
+    expect(src).toMatch(/FILTER_KEYS\s*=\s*new Set\s*\(\s*Object\.keys\s*\(\s*DEFAULT_FILTERS/);
+  });
+
+  it('_onFilterChange guards with FILTER_KEYS.has(filter)', () => {
+    const fn = src.slice(src.lastIndexOf('_onFilterChange(e)'), src.lastIndexOf('_onFilterChange(e)') + 200);
+    expect(fn).toMatch(/FILTER_KEYS\.has\s*\(\s*filter\s*\)/);
+  });
+
+  it('_rfApply guards with FILTER_KEYS.has(filter)', () => {
+    const fn = src.slice(src.indexOf('_rfApply('), src.indexOf('_rfApply(') + 200);
+    expect(fn).toMatch(/FILTER_KEYS\.has\s*\(\s*filter\s*\)/);
   });
 });
 
@@ -114,8 +132,8 @@ describe('ol-search-page filter consolidation — buildChips called inline', () 
     expect(renderFn).toMatch(/buildChips\s*\(\s*this\._filters\s*\)/);
   });
 
-  it('updated() dispatches ol-app-state with buildChips(this._filters) for chips', () => {
-    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
-    expect(fn).toMatch(/buildChips\s*\(\s*this\._filters\s*\)/);
+  it('updated() dispatches ol-app-state with buildChips() for chips', () => {
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 600);
+    expect(fn).toMatch(/buildChips\s*\(/);
   });
 });

--- a/frontend/src/components/ol-search-page.filter-object.test.js
+++ b/frontend/src/components/ol-search-page.filter-object.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dir = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dir, 'ol-search-page.js'), 'utf8');
+
+// ── Static properties contract ────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — static properties', () => {
+  it('declares _filters as a single reactive state property', () => {
+    expect(src).toMatch(/_filters\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _sort as an individual reactive property', () => {
+    expect(src).not.toMatch(/_sort\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _availability as an individual reactive property', () => {
+    expect(src).not.toMatch(/_availability\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _fictionFilter as an individual reactive property', () => {
+    expect(src).not.toMatch(/_fictionFilter\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _languages as an individual reactive property', () => {
+    expect(src).not.toMatch(/_languages\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _genres as an individual reactive property', () => {
+    expect(src).not.toMatch(/_genres\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _authors as an individual reactive property', () => {
+    expect(src).not.toMatch(/_authors\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+
+  it('does not declare _subjects as an individual reactive property', () => {
+    expect(src).not.toMatch(/_subjects\s*:\s*\{\s*state\s*:\s*true\s*\}/);
+  });
+});
+
+// ── Constructor contract ───────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — constructor', () => {
+  it('initialises _filters from DEFAULT_FILTERS in constructor', () => {
+    const ctor = src.slice(src.indexOf('constructor()'), src.indexOf('constructor()') + 600);
+    expect(ctor).toMatch(/this\._filters\s*=\s*\{\s*\.\.\.DEFAULT_FILTERS\s*\}/);
+  });
+
+  it('constructor does not assign this._sort individually', () => {
+    const ctor = src.slice(src.indexOf('constructor()'), src.indexOf('constructor()') + 600);
+    expect(ctor).not.toMatch(/this\._sort\s*=/);
+  });
+
+  it('constructor does not assign this._availability individually', () => {
+    const ctor = src.slice(src.indexOf('constructor()'), src.indexOf('constructor()') + 600);
+    expect(ctor).not.toMatch(/this\._availability\s*=/);
+  });
+});
+
+// ── No getter contract ────────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — no computed getters', () => {
+  it('does not have a get _filters() computed getter (it is now reactive state)', () => {
+    expect(src).not.toMatch(/get\s+_filters\s*\(\s*\)/);
+  });
+
+  it('does not have a get _chips() computed getter', () => {
+    expect(src).not.toMatch(/get\s+_chips\s*\(\s*\)/);
+  });
+});
+
+// ── Mutation patterns ─────────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — mutation via spread', () => {
+  it('_onFilterChange uses computed property spread: { ...this._filters, [filter]: value }', () => {
+    const fn = src.slice(src.lastIndexOf('_onFilterChange(e)'), src.lastIndexOf('_onFilterChange(e)') + 300);
+    expect(fn).toMatch(/\{\s*\.\.\.\s*this\._filters\s*,\s*\[filter\]\s*:\s*value\s*\}/);
+  });
+
+  it('_rfApply uses computed property spread: { ...this._filters, [filter]: value }', () => {
+    const fn = src.slice(src.indexOf('_rfApply('), src.indexOf('_rfApply(') + 200);
+    expect(fn).toMatch(/\{\s*\.\.\.\s*this\._filters\s*,\s*\[filter\]\s*:\s*value\s*\}/);
+  });
+
+  it('_onClearAllFilters resets _filters using DEFAULT_FILTERS spread', () => {
+    const fn = src.slice(src.indexOf('_onClearAllFilters() {'), src.indexOf('_onClearAllFilters() {') + 200);
+    expect(fn).toMatch(/this\._filters\s*=\s*\{\s*\.\.\.DEFAULT_FILTERS\s*\}/);
+  });
+});
+
+// ── updated() contract ────────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — updated() watches _filters', () => {
+  it('updated() checks changed.has("_filters") not individual filter props', () => {
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
+    expect(fn).toMatch(/changed\.has\s*\(\s*['"]_filters['"]\s*\)/);
+  });
+
+  it('updated() does not check changed.has("_sort")', () => {
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
+    expect(fn).not.toMatch(/changed\.has\s*\(\s*['"]_sort['"]\s*\)/);
+  });
+});
+
+// ── buildChips inline call ────────────────────────────────────────────────────
+
+describe('ol-search-page filter consolidation — buildChips called inline', () => {
+  it('render passes buildChips(this._filters) to ol-search-bar chips prop', () => {
+    const renderFn = src.slice(src.lastIndexOf('render()'), src.lastIndexOf('render()') + 1200);
+    expect(renderFn).toMatch(/buildChips\s*\(\s*this\._filters\s*\)/);
+  });
+
+  it('updated() dispatches ol-app-state with buildChips(this._filters) for chips', () => {
+    const fn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 300);
+    expect(fn).toMatch(/buildChips\s*\(\s*this\._filters\s*\)/);
+  });
+});

--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -12,6 +12,7 @@ import {
 import { fetchAuthorSuggestions, fetchSubjectSuggestions } from '../utils/facets.js';
 
 const LIMIT = 20;
+const FILTER_KEYS = new Set(Object.keys(DEFAULT_FILTERS));
 
 const SHOWCASE_BOOKS = [
   { olid: 'OL27448W',   title: 'The Lord of the Rings',        href: 'https://openlibrary.org/works/OL27448W' },
@@ -135,8 +136,14 @@ export class OlSearchPage extends LitElement {
 
   updated(changed) {
     if (changed.has('_lastQ') || changed.has('_filters')) {
+      const f = this._filters;
       window.dispatchEvent(new CustomEvent('ol-app-state', {
-        detail: { hasQuery: this._lastQ !== null, filters: this._filters, chips: buildChips(this._filters) },
+        detail: {
+          hasQuery: this._lastQ !== null,
+          // Defensive copy — listeners must not mutate internal state.
+          filters: { ...f, languages: [...f.languages], genres: [...f.genres], authors: [...f.authors], subjects: [...f.subjects] },
+          chips: buildChips(f),
+        },
       }));
     }
   }
@@ -149,13 +156,12 @@ export class OlSearchPage extends LitElement {
     const f = e.detail?.filters;
     if (f) {
       this._filters = {
-        sort:          f.sort          ?? DEFAULT_FILTERS.sort,
-        availability:  f.availability  ?? DEFAULT_FILTERS.availability,
-        fictionFilter: f.fictionFilter ?? DEFAULT_FILTERS.fictionFilter,
-        languages:     [...(f.languages ?? [])],
-        genres:        [...(f.genres    ?? [])],
-        authors:       [...(f.authors   ?? [])],
-        subjects:      [...(f.subjects  ?? [])],
+        ...DEFAULT_FILTERS,
+        ...f,
+        languages: [...(f.languages ?? [])],
+        genres:    [...(f.genres    ?? [])],
+        authors:   [...(f.authors   ?? [])],
+        subjects:  [...(f.subjects  ?? [])],
       };
     }
     const url = new URL(location.href);
@@ -224,6 +230,7 @@ export class OlSearchPage extends LitElement {
   // ── Filter changes from ol-search-bar ─────────────────────────
   _onFilterChange(e) {
     const { filter, value } = e.detail;
+    if (!FILTER_KEYS.has(filter)) return;
     this._filters = { ...this._filters, [filter]: value };
     if (this._lastQ !== null) this._runSearch(1);
   }
@@ -266,6 +273,7 @@ export class OlSearchPage extends LitElement {
 
   _rfApply(filter, value, keepOpen = false) {
     if (!keepOpen) this._openFacet = null;
+    if (!FILTER_KEYS.has(filter)) return;
     this._filters = { ...this._filters, [filter]: value };
     this._runSearch(1);
   }

--- a/frontend/src/components/ol-search-page.js
+++ b/frontend/src/components/ol-search-page.js
@@ -6,7 +6,7 @@ import './ol-howto-modal.js';
 import './ol-search-hint.js';
 import {
   POPULAR_AUTHORS, POPULAR_SUBJECTS,
-  EMPTY_FILTERS, buildChips, buildSearchParams, shufflePick,
+  DEFAULT_FILTERS, buildChips, buildSearchParams, shufflePick,
   getSortLabel,
 } from '../utils/filters.js';
 import { fetchAuthorSuggestions, fetchSubjectSuggestions } from '../utils/facets.js';
@@ -53,14 +53,8 @@ export class OlSearchPage extends LitElement {
     _page:      { state: true },
     _lastQ:     { state: true },
 
-    // Filters (canonical state)
-    _sort:          { state: true },
-    _availability:  { state: true },
-    _fictionFilter: { state: true },
-    _languages:     { state: true },
-    _genres:        { state: true },
-    _authors:       { state: true },
-    _subjects:      { state: true },
+    // Filters (canonical state — single object, not 7 individual props)
+    _filters: { state: true },
 
     // Results filter bar UI state
     _openFacet:       { state: true },
@@ -83,13 +77,7 @@ export class OlSearchPage extends LitElement {
     this._page      = 1;
     this._lastQ     = null;
 
-    this._sort          = EMPTY_FILTERS.sort;
-    this._availability  = EMPTY_FILTERS.availability;
-    this._fictionFilter = EMPTY_FILTERS.fictionFilter;
-    this._languages     = [...EMPTY_FILTERS.languages];
-    this._genres        = [...EMPTY_FILTERS.genres];
-    this._authors       = [...EMPTY_FILTERS.authors];
-    this._subjects      = [...EMPTY_FILTERS.subjects];
+    this._filters = { ...DEFAULT_FILTERS };
 
     this._openFacet       = null;
     this._howtoOpen       = false;
@@ -146,36 +134,11 @@ export class OlSearchPage extends LitElement {
   }
 
   updated(changed) {
-    const broadcast = ['_lastQ', '_sort', '_availability', '_fictionFilter', '_languages', '_genres', '_authors', '_subjects'];
-    if (broadcast.some(k => changed.has(k))) {
+    if (changed.has('_lastQ') || changed.has('_filters')) {
       window.dispatchEvent(new CustomEvent('ol-app-state', {
-        detail: { hasQuery: this._lastQ !== null, filters: this._filters, chips: this._chips },
+        detail: { hasQuery: this._lastQ !== null, filters: this._filters, chips: buildChips(this._filters) },
       }));
     }
-  }
-
-  // ── Computed helpers ──────────────────────────────────────────
-  get _chips() {
-    return buildChips({
-      availability:  this._availability,
-      fictionFilter: this._fictionFilter,
-      languages:     this._languages,
-      genres:        this._genres,
-      authors:       this._authors,
-      subjects:      this._subjects,
-    });
-  }
-
-  get _filters() {
-    return {
-      sort:          this._sort,
-      availability:  this._availability,
-      fictionFilter: this._fictionFilter,
-      languages:     this._languages,
-      genres:        this._genres,
-      authors:       this._authors,
-      subjects:      this._subjects,
-    };
   }
 
   // ── Search ────────────────────────────────────────────────────
@@ -185,13 +148,15 @@ export class OlSearchPage extends LitElement {
     // the user set in the droppable so the results match what was shown in autocomplete.
     const f = e.detail?.filters;
     if (f) {
-      this._sort          = f.sort          ?? EMPTY_FILTERS.sort;
-      this._availability  = f.availability  ?? EMPTY_FILTERS.availability;
-      this._fictionFilter = f.fictionFilter ?? EMPTY_FILTERS.fictionFilter;
-      this._languages     = [...(f.languages ?? [])];
-      this._genres        = [...(f.genres    ?? [])];
-      this._authors       = [...(f.authors   ?? [])];
-      this._subjects      = [...(f.subjects  ?? [])];
+      this._filters = {
+        sort:          f.sort          ?? DEFAULT_FILTERS.sort,
+        availability:  f.availability  ?? DEFAULT_FILTERS.availability,
+        fictionFilter: f.fictionFilter ?? DEFAULT_FILTERS.fictionFilter,
+        languages:     [...(f.languages ?? [])],
+        genres:        [...(f.genres    ?? [])],
+        authors:       [...(f.authors   ?? [])],
+        subjects:      [...(f.subjects  ?? [])],
+      };
     }
     const url = new URL(location.href);
     url.searchParams.set('q', this._lastQ);
@@ -256,30 +221,16 @@ export class OlSearchPage extends LitElement {
       ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 
-  // ── Filter changes from ol-search-bar (hero) ──────────────────
+  // ── Filter changes from ol-search-bar ─────────────────────────
   _onFilterChange(e) {
     const { filter, value } = e.detail;
-    switch (filter) {
-      case 'sort':          this._sort          = value; break;
-      case 'availability':  this._availability  = value; break;
-      case 'fictionFilter': this._fictionFilter = value; break;
-      case 'languages':     this._languages     = value; break;
-      case 'genres':        this._genres        = value; break;
-      case 'authors':       this._authors       = value; break;
-      case 'subjects':      this._subjects      = value; break;
-    }
+    this._filters = { ...this._filters, [filter]: value };
     if (this._lastQ !== null) this._runSearch(1);
   }
 
   // ── Clear all filters ─────────────────────────────────────────
   _onClearAllFilters() {
-    this._sort          = EMPTY_FILTERS.sort;
-    this._availability  = EMPTY_FILTERS.availability;
-    this._fictionFilter = EMPTY_FILTERS.fictionFilter;
-    this._languages     = [...EMPTY_FILTERS.languages];
-    this._genres        = [...EMPTY_FILTERS.genres];
-    this._authors       = [...EMPTY_FILTERS.authors];
-    this._subjects      = [...EMPTY_FILTERS.subjects];
+    this._filters = { ...DEFAULT_FILTERS };
     if (this._lastQ !== null) this._runSearch(1);
   }
 
@@ -315,15 +266,7 @@ export class OlSearchPage extends LitElement {
 
   _rfApply(filter, value, keepOpen = false) {
     if (!keepOpen) this._openFacet = null;
-    switch (filter) {
-      case 'sort':          this._sort          = value; break;
-      case 'availability':  this._availability  = value; break;
-      case 'fictionFilter': this._fictionFilter = value; break;
-      case 'languages':     this._languages     = value; break;
-      case 'genres':        this._genres        = value; break;
-      case 'authors':       this._authors       = value; break;
-      case 'subjects':      this._subjects      = value; break;
-    }
+    this._filters = { ...this._filters, [filter]: value };
     this._runSearch(1);
   }
 
@@ -447,27 +390,29 @@ export class OlSearchPage extends LitElement {
   // ── Results filter bar render ─────────────────────────────────
 
   _rfLabel(name) {
+    const f = this._filters;
     switch (name) {
-      case 'sort':   return this._sort ? getSortLabel(this._sort) : 'Sort by';
+      case 'sort':   return f.sort ? getSortLabel(f.sort) : 'Sort by';
       case 'avail':  return 'Availability';
-      case 'lang':   return this._languages.length ? `Language (${this._languages.length})` : 'Language';
+      case 'lang':   return f.languages.length ? `Language (${f.languages.length})` : 'Language';
       case 'genre': {
-        const total = this._genres.length + (this._fictionFilter ? 1 : 0);
+        const total = f.genres.length + (f.fictionFilter ? 1 : 0);
         return total ? `Genre (${total})` : 'Genre';
       }
-      case 'author': return this._authors.length  ? `Author (${this._authors.length})`  : 'Author';
-      case 'subject':return this._subjects.length ? `Subject (${this._subjects.length})`: 'Subject';
+      case 'author': return f.authors.length  ? `Author (${f.authors.length})`  : 'Author';
+      case 'subject':return f.subjects.length ? `Subject (${f.subjects.length})`: 'Subject';
     }
   }
 
   _rfActive(name) {
+    const f = this._filters;
     switch (name) {
-      case 'sort':   return !!this._sort;
-      case 'avail':  return !!this._availability;
-      case 'lang':   return this._languages.length > 0;
-      case 'genre':  return this._genres.length > 0 || !!this._fictionFilter;
-      case 'author': return this._authors.length > 0;
-      case 'subject':return this._subjects.length > 0;
+      case 'sort':   return !!f.sort;
+      case 'avail':  return !!f.availability;
+      case 'lang':   return f.languages.length > 0;
+      case 'genre':  return f.genres.length > 0 || !!f.fictionFilter;
+      case 'author': return f.authors.length > 0;
+      case 'subject':return f.subjects.length > 0;
     }
   }
 
@@ -544,7 +489,7 @@ export class OlSearchPage extends LitElement {
       <div class="results-wrap">
         <ol-search-bar
           .q=${this._lastQ ?? ''}
-          .chips=${this._chips}
+          .chips=${buildChips(this._filters)}
           .filters=${this._filters}
         ></ol-search-bar>
 


### PR DESCRIPTION
Closes #37

## Summary

- Replaces `_sort`, `_availability`, `_fictionFilter`, `_languages`, `_genres`, `_authors`, `_subjects` (7 individual Lit reactive properties) with a single `_filters: { state: true }` object initialised from `DEFAULT_FILTERS`
- Removes the `get _filters()` and `get _chips()` computed getters — `_filters` is now direct reactive state, chips are computed inline with `buildChips(this._filters)`
- All mutation sites collapse to a single spread: `_onFilterChange` and `_rfApply` use `{ ...this._filters, [filter]: value }`; `_onClearAllFilters` uses `{ ...DEFAULT_FILTERS }`
- `updated()` now watches two properties (`_lastQ`, `_filters`) instead of eight

## Test plan

- [x] 13 static-analysis tests added in `ol-search-page.filter-object.test.js` covering: `_filters` declared as reactive state, 7 individual props not declared, constructor initialisation, no getter methods, spread mutation patterns, `updated()` watches `_filters`, `buildChips` called inline
- [x] All 187 unit tests pass
- [x] Lint clean