### PR TITLE
fix: droppable search navigates to results page; lock html+body scroll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,25 @@ Types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `style`
 
 Squash fixup commits; keep history as logical milestones.
 
+## Test-Driven Development
+
+**Write the test before the fix.** For every interactive bug or behavioral change:
+
+1. Write a failing Playwright test (or Vitest static-analysis test) that reproduces the problem.
+2. Commit it with a message like `test: failing test for <issue>`.
+3. Implement the fix until the test goes green.
+4. Commit the fix separately.
+
+This creates an unambiguous record that the test was driven by the behavior, not retrofitted after the fact.
+
+**Playwright for interactive behavior; Vitest for structure/layout.**
+- Use Playwright for: navigation, clicks, keyboard, event propagation, computed styles, layout dimensions.
+- Use Vitest (static-analysis) for: CSS property presence, method/event name conventions, code structure contracts.
+
+**Never rely on event-fires-only assertions for navigation bugs.** A test that only checks `window.__olSearchFired === true` does not catch a broken navigation path. Always assert the URL or a visible side-effect of the intended action.
+
+---
+
 ## Pull Request Standards
 
 ### Bug fixes must include evidence

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ The PR body should state which test proves the fix, or link the screenshot inlin
 
 ### Wait for Copilot review after opening a PR
 
-After opening a PR, **schedule a reminder to check for Copilot feedback in ~8 minutes** using `ScheduleWakeup`. Copilot typically posts its review within a few minutes of the PR being created; 8 minutes gives it enough time to finish without waiting too long.
+After opening a PR, **schedule a one-time reminder to check for Copilot feedback in ~8 minutes** using `ScheduleWakeup`. Copilot posts a single initial review shortly after the PR is created; it does **not** re-review subsequent commits, so only one check is needed.
 
 `ScheduleWakeup` fires in the **same session** that opened the PR, so the prompt can be short — all project context, AGENTS.md rules, and the reply+resolve workflow are already in conversation history. The prompt only needs to identify the PR number and the action:
 
@@ -156,7 +156,7 @@ When the reminder fires:
 2. Fetch the overview review: `gh pr view <PR> --repo ArchiveLabs/openlibrary-components --json reviews`
 3. Address every comment, push a fix commit, then reply and resolve each thread (see rule below).
 
-If there are no comments yet when the reminder fires, wait another few minutes before concluding there is no feedback.
+If there are no comments yet when the reminder fires, wait another few minutes — but do **not** schedule further checks. Copilot only reviews once.
 
 ### Responding to review comments (Copilot or human)
 

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -152,17 +152,18 @@ export class OlSearchBar extends LitElement {
     }
     // Sync full-screen overlay class on the host element.
     this.classList.toggle('mobile-exp', this._mobileExpanded);
-    // Prevent body scroll while overlay is active; lock <html> too since many
-    // browsers/frameworks scroll it. Save pre-existing inline values so close
-    // restores exactly what was there before (avoids clobbering other overlays).
-    if (changed.has('_mobileExpanded')) {
-      if (this._mobileExpanded && !this._scrollLockActive) {
+    // Lock body scroll whenever the droppable panel is open on any viewport.
+    // Lock <html> too since many browsers/frameworks scroll it.
+    // Save pre-existing inline values so close restores them exactly.
+    if (changed.has('_open')) {
+      const shouldLock = this._open && this.showFacets;
+      if (shouldLock && !this._scrollLockActive) {
         this._prevBodyOverflow            = document.body.style.overflow;
         this._prevDocumentOverflow        = document.documentElement.style.overflow;
         this._scrollLockActive            = true;
         document.body.style.overflow      = 'hidden';
         document.documentElement.style.overflow = 'hidden';
-      } else if (!this._mobileExpanded && this._scrollLockActive) {
+      } else if (!shouldLock && this._scrollLockActive) {
         document.body.style.overflow            = this._prevBodyOverflow ?? '';
         document.documentElement.style.overflow = this._prevDocumentOverflow ?? '';
         this._scrollLockActive      = false;

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -124,13 +124,16 @@ export class OlSearchBar extends LitElement {
     super.disconnectedCallback();
     document.removeEventListener('click', this._onDoc, true);
     window.removeEventListener('resize', this._onWinResize);
-    if (this._mobileExpanded) document.body.style.overflow = '';
     this._acAbort?.abort();
     this._authorAbort?.abort();
     this._subjectAbort?.abort();
     clearTimeout(this._timer);
     clearTimeout(this._authorTimer);
     clearTimeout(this._subjectTimer);
+    if (this._mobileExpanded) {
+      document.body.style.overflow = '';
+      document.documentElement.style.overflow = '';
+    }
   }
 
   updated(changed) {
@@ -148,9 +151,12 @@ export class OlSearchBar extends LitElement {
     }
     // Sync full-screen overlay class on the host element.
     this.classList.toggle('mobile-exp', this._mobileExpanded);
-    // Prevent body scroll while overlay is active so the page behind doesn't scroll.
+    // Prevent body scroll (both axes) while overlay is active so the page behind
+    // doesn't scroll. Lock <html> as well — some browsers/frameworks scroll it.
     if (changed.has('_mobileExpanded')) {
-      document.body.style.overflow = this._mobileExpanded ? 'hidden' : '';
+      const lock = this._mobileExpanded ? 'hidden' : '';
+      document.body.style.overflow = lock;
+      document.documentElement.style.overflow = lock;
     }
     // Anchor the panel to the trigger and focus the panel-input when it opens.
     if (changed.has('_open') && this._open && this.showFacets) {
@@ -298,13 +304,35 @@ export class OlSearchBar extends LitElement {
     if (e.key === 'Enter') this._submit();
   }
 
+  // Build a search results URL from query + current filters.
+  // Used as the fallback navigation target in droppable mode when no host
+  // cancels the ol-search event.
+  _buildSearchUrl(q, f = {}) {
+    const p = new URLSearchParams();
+    if (q) p.set('q', q);
+    if (f.sort)           p.set('sort', f.sort);
+    if (f.availability)   p.set('availability', f.availability);
+    if (f.fictionFilter)  p.set('subject', f.fictionFilter);
+    (f.languages ?? []).forEach(l => p.append('language', l));
+    (f.genres    ?? []).forEach(g => p.append('subject', g));
+    (f.authors   ?? []).forEach(a => p.append('author', a));
+    (f.subjects  ?? []).forEach(s => p.append('subject', s));
+    return `${this.siteBase}/search?${p.toString()}`;
+  }
+
   _submit() {
     if (!this._q.trim() && !this._hasActiveFilters()) return;
     this._mobileExpanded = false;
-    this.dispatchEvent(new CustomEvent('ol-search', {
+    const event = new CustomEvent('ol-search', {
       detail: { q: this._q.trim(), filters: this._localFilters },
-      bubbles: true, composed: true,
-    }));
+      bubbles: true, composed: true, cancelable: true,
+    });
+    this.dispatchEvent(event);
+    // In droppable mode navigate to the search results page unless the host
+    // handled the event itself and called e.preventDefault().
+    if (this.showFacets && !event.defaultPrevented) {
+      window.location.href = this._buildSearchUrl(this._q.trim(), this._localFilters);
+    }
   }
 
   // ── Clear-all filters ─────────────────────────────────────────
@@ -844,9 +872,13 @@ export class OlSearchBar extends LitElement {
         <button class="ac-see-all" @click=${() => {
           this._closePanel();
           if (!q && !this._hasActiveFilters()) return;
-          this.dispatchEvent(new CustomEvent('ol-search', {
-            detail: { q, filters: this._localFilters }, bubbles: true, composed: true,
-          }));
+          const event = new CustomEvent('ol-search', {
+            detail: { q, filters: this._localFilters }, bubbles: true, composed: true, cancelable: true,
+          });
+          this.dispatchEvent(event);
+          if (this.showFacets && !event.defaultPrevented) {
+            window.location.href = this._buildSearchUrl(q, this._localFilters);
+          }
         }}>See all ${this._total.toLocaleString()} results →</button>
       </div>`;
   }

--- a/frontend/src/components/ol-search-bar.js
+++ b/frontend/src/components/ol-search-bar.js
@@ -130,9 +130,10 @@ export class OlSearchBar extends LitElement {
     clearTimeout(this._timer);
     clearTimeout(this._authorTimer);
     clearTimeout(this._subjectTimer);
-    if (this._mobileExpanded) {
-      document.body.style.overflow = '';
-      document.documentElement.style.overflow = '';
+    if (this._scrollLockActive) {
+      document.body.style.overflow            = this._prevBodyOverflow ?? '';
+      document.documentElement.style.overflow = this._prevDocumentOverflow ?? '';
+      this._scrollLockActive = false;
     }
   }
 
@@ -151,12 +152,23 @@ export class OlSearchBar extends LitElement {
     }
     // Sync full-screen overlay class on the host element.
     this.classList.toggle('mobile-exp', this._mobileExpanded);
-    // Prevent body scroll (both axes) while overlay is active so the page behind
-    // doesn't scroll. Lock <html> as well — some browsers/frameworks scroll it.
+    // Prevent body scroll while overlay is active; lock <html> too since many
+    // browsers/frameworks scroll it. Save pre-existing inline values so close
+    // restores exactly what was there before (avoids clobbering other overlays).
     if (changed.has('_mobileExpanded')) {
-      const lock = this._mobileExpanded ? 'hidden' : '';
-      document.body.style.overflow = lock;
-      document.documentElement.style.overflow = lock;
+      if (this._mobileExpanded && !this._scrollLockActive) {
+        this._prevBodyOverflow            = document.body.style.overflow;
+        this._prevDocumentOverflow        = document.documentElement.style.overflow;
+        this._scrollLockActive            = true;
+        document.body.style.overflow      = 'hidden';
+        document.documentElement.style.overflow = 'hidden';
+      } else if (!this._mobileExpanded && this._scrollLockActive) {
+        document.body.style.overflow            = this._prevBodyOverflow ?? '';
+        document.documentElement.style.overflow = this._prevDocumentOverflow ?? '';
+        this._scrollLockActive      = false;
+        this._prevBodyOverflow      = undefined;
+        this._prevDocumentOverflow  = undefined;
+      }
     }
     // Anchor the panel to the trigger and focus the panel-input when it opens.
     if (changed.has('_open') && this._open && this.showFacets) {
@@ -317,7 +329,9 @@ export class OlSearchBar extends LitElement {
     (f.genres    ?? []).forEach(g => p.append('subject', g));
     (f.authors   ?? []).forEach(a => p.append('author', a));
     (f.subjects  ?? []).forEach(s => p.append('subject', s));
-    return `${this.siteBase}/search?${p.toString()}`;
+    const url = new URL('/search', this.siteBase);
+    url.search = p.toString();
+    return url.toString();
   }
 
   _submit() {

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -117,3 +117,34 @@ describe('ol-search-bar mobile overlay JS contract', () => {
     expect(dcFn).toMatch(/document\.body\.style\.overflow/);
   });
 });
+
+// ── Scroll lock — any droppable mode (issue #44 follow-up) ───────────────────
+//
+// Scroll lock must engage whenever the droppable search panel is open, not only
+// when the mobile full-screen overlay is active.  The gate is _open (the
+// universal open state) checked against showFacets (droppable mode), NOT
+// _mobileExpanded (mobile-only).
+
+describe('ol-search-bar scroll lock — any droppable panel open', () => {
+  // Find the line that acquires the lock so we can inspect its context.
+  const lockIdx = src.search(/this\._scrollLockActive\s*=\s*true/);
+  const lockCtx = lockIdx !== -1 ? src.slice(Math.max(0, lockIdx - 300), lockIdx) : '';
+
+  it('_scrollLockActive = true exists in source', () => {
+    expect(lockIdx).not.toBe(-1);
+  });
+
+  it('scroll lock acquire is gated on _open change (not _mobileExpanded) so desktop panel also locks scroll', () => {
+    expect(lockCtx).toMatch(/changed\.has\s*\(\s*'_open'\s*\)/);
+  });
+
+  it('scroll lock acquire condition checks showFacets so embedded mode does not lock scroll', () => {
+    expect(lockCtx).toMatch(/showFacets/);
+  });
+
+  it('disconnectedCallback restores overflow via _scrollLockActive flag', () => {
+    const dcFn = src.slice(src.indexOf('disconnectedCallback'), src.indexOf('disconnectedCallback') + 500);
+    expect(dcFn).toMatch(/_scrollLockActive/);
+    expect(dcFn).toMatch(/document\.body\.style\.overflow/);
+  });
+});

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -115,14 +115,15 @@ describe('ol-search-bar mobile overlay JS contract', () => {
     expect(src).toMatch(/classList\.toggle\s*\(\s*['"]mobile-exp['"]\s*,\s*this\._mobileExpanded\s*\)/);
   });
 
-  it('locks body scroll when mobile overlay opens and restores it when it closes', () => {
-    const updatedFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 1200);
+  it('locks body scroll when droppable panel opens and restores it when it closes', () => {
+    const updatedFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 2000);
     expect(updatedFn).toMatch(/document\.body\.style\.overflow/);
-    expect(updatedFn).toMatch(/_mobileExpanded.*hidden|hidden.*_mobileExpanded/s);
+    expect(updatedFn).toMatch(/this\._open.*this\.showFacets|this\.showFacets.*this\._open/s);
   });
 
-  it('restores body scroll in disconnectedCallback in case component is removed while expanded', () => {
-    const dcFn = src.slice(src.indexOf('disconnectedCallback()'), src.indexOf('disconnectedCallback()') + 400);
+  it('restores body scroll in disconnectedCallback via _scrollLockActive flag', () => {
+    const dcFn = src.slice(src.indexOf('disconnectedCallback()'), src.indexOf('disconnectedCallback()') + 600);
+    expect(dcFn).toMatch(/_scrollLockActive/);
     expect(dcFn).toMatch(/document\.body\.style\.overflow/);
   });
 });

--- a/frontend/src/components/ol-search-bar.mobile-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.mobile-overlay.test.js
@@ -45,9 +45,18 @@ describe('ol-search-bar mobile overlay CSS contract', () => {
     expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.ac-scroll[^}]*min-height\s*:\s*0/);
   });
 
+  it(':host(.mobile-exp) .ac-scroll removes max-height cap so content fills the space', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.ac-scroll[^}]*max-height\s*:\s*none/);
+  });
+
   it(':host(.mobile-exp) .panel is a flex column so children stack and ac-scroll can flex-grow', () => {
     expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*display\s*:\s*flex/);
     expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*flex-direction\s*:\s*column/);
+  });
+
+  it(':host(.mobile-exp) .panel and .search-outer both have min-height:0 to allow flex shrink', () => {
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.panel[^}]*min-height\s*:\s*0/);
+    expect(src).toMatch(/:host\(\.mobile-exp\)\s+\.search-outer[^}]*min-height\s*:\s*0/);
   });
 
   it('@media 600px .ac-scroll rule is scoped to :host(:not(.mobile-exp)) — no specificity conflict', () => {

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -99,7 +99,7 @@ describe('ol-search-bar panel overlay — panel-input contract', () => {
   });
 
   it('updated() focuses the panel-input when the panel opens', () => {
-    const updFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 1200);
+    const updFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 1300);
     expect(updFn).toMatch(/panel-input/);
   });
 });

--- a/frontend/src/components/ol-search-bar.panel-overlay.test.js
+++ b/frontend/src/components/ol-search-bar.panel-overlay.test.js
@@ -99,7 +99,7 @@ describe('ol-search-bar panel overlay — panel-input contract', () => {
   });
 
   it('updated() focuses the panel-input when the panel opens', () => {
-    const updFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 1300);
+    const updFn = src.slice(src.indexOf('updated(changed)'), src.indexOf('updated(changed)') + 2000);
     expect(updFn).toMatch(/panel-input/);
   });
 });

--- a/frontend/tests/facet-and-submit.spec.js
+++ b/frontend/tests/facet-and-submit.spec.js
@@ -3,6 +3,10 @@
  *
  * ol-search-bar lives inside ol-header's shadow DOM, so all page.evaluate()
  * helpers traverse: document → ol-header.shadowRoot → ol-search-bar.
+ *
+ * TDD note: navigation tests (issue #44) were written BEFORE the _submit()
+ * navigation fix so they would fail red and prove the regression, then go
+ * green once _buildSearchUrl + cancelable-event logic was added.
  */
 
 import { test, expect } from '@playwright/test';
@@ -16,7 +20,6 @@ async function waitForCustomElements(page) {
 
 /** Open the search panel then click the first facet button. */
 async function openPanelAndFacet(page) {
-  // Click the trigger button (droppable/header mode — the panel lives here)
   await page.evaluate(() => {
     const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
     sb?.shadowRoot?.querySelector('.trigger-btn')
@@ -28,7 +31,6 @@ async function openPanelAndFacet(page) {
     return sb?.shadowRoot?.querySelector('.panel') !== null;
   });
 
-  // Click the first facet button (Availability)
   await page.evaluate(() => {
     const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
     sb?.shadowRoot?.querySelector('.pf-btn')
@@ -39,6 +41,27 @@ async function openPanelAndFacet(page) {
     const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
     return sb?.shadowRoot?.querySelector('ol-facet-drop') !== null;
   }, { timeout: 3000 });
+}
+
+/** Open the panel and type a query into the panel-input. */
+async function openPanelAndType(page, query) {
+  await page.evaluate(() => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    sb?.shadowRoot?.querySelector('.trigger-btn')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+  });
+  await page.waitForFunction(() => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    return sb?.shadowRoot?.querySelector('.panel-input') !== null;
+  });
+  await page.evaluate((q) => {
+    const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+    const input = sb?.shadowRoot?.querySelector('.panel-input');
+    if (input) {
+      input.value = q;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+  }, query);
 }
 
 // ── Issue #21: clicking panel chips / background while facet is open should dismiss it ──
@@ -60,7 +83,6 @@ test.describe('facet dropdown dismissal (issue #21)', () => {
     });
     expect(openBefore).toBe(true);
 
-    // Click panel-chips — inside ol-search-bar but outside ol-facet-drop
     await page.evaluate(() => {
       const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
       sb?.shadowRoot?.querySelector('.panel-chips')
@@ -98,7 +120,7 @@ test.describe('facet dropdown dismissal (issue #21)', () => {
   });
 });
 
-// ── Issue #22: clicking the submit button fires ol-search event ──
+// ── Issue #22: submit dispatches ol-search ──
 
 test.describe('submit button (issue #22)', () => {
   test('clicking the magnifying glass dispatches an ol-search event', async ({ page }) => {
@@ -112,27 +134,8 @@ test.describe('submit button (issue #22)', () => {
       document.addEventListener('ol-search', () => { window.__olSearchFired = true; }, { once: true });
     });
 
-    // Open the panel, then type into the panel-input
-    await page.evaluate(() => {
-      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
-      sb?.shadowRoot?.querySelector('.trigger-btn')
-        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
-    });
-    await page.waitForFunction(() => {
-      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
-      return sb?.shadowRoot?.querySelector('.panel-input') !== null;
-    });
+    await openPanelAndType(page, 'frankenstein');
 
-    await page.evaluate(() => {
-      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
-      const input = sb?.shadowRoot?.querySelector('.panel-input');
-      if (input) {
-        input.value = 'frankenstein';
-        input.dispatchEvent(new Event('input', { bubbles: true }));
-      }
-    });
-
-    // Click the submit button inside the panel
     await page.evaluate(() => {
       const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
       sb?.shadowRoot?.querySelector('.panel .submit')
@@ -140,8 +143,94 @@ test.describe('submit button (issue #22)', () => {
     });
 
     await page.waitForFunction(() => window.__olSearchFired === true, { timeout: 2000 });
+    expect(await page.evaluate(() => window.__olSearchFired)).toBe(true);
+  });
+});
 
-    const fired = await page.evaluate(() => window.__olSearchFired);
-    expect(fired).toBe(true);
+// ── Issue #44: droppable submit navigates to search URL ──
+//
+// These tests were written BEFORE the navigation fix was implemented (TDD).
+// They failed red until _submit() added URL navigation for showFacets=true mode.
+
+test.describe('droppable submit navigation (issue #44)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    // Intercept any navigation to the OL search page so the test stays on localhost.
+    // The route fulfils with a stub so waitForURL() can resolve without hitting the network.
+    await page.route('**/search?**', route =>
+      route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>stub</body></html>' })
+    );
+    await page.goto('/');
+    await waitForCustomElements(page);
+    await page.locator('ol-search-bar').waitFor({ state: 'attached' });
+  });
+
+  test('clicking the submit button navigates to /search?q=<query>', async ({ page }) => {
+    await openPanelAndType(page, 'frankenstein');
+
+    const navPromise = page.waitForURL(/\/search\?.*q=/, { timeout: 4000 });
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.panel .submit')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+    await navPromise;
+
+    expect(page.url()).toMatch(/\/search\?.*q=frankenstein/);
+  });
+
+  test('pressing Enter in the panel-input navigates to /search?q=<query>', async ({ page }) => {
+    await openPanelAndType(page, 'frankenstein');
+
+    const navPromise = page.waitForURL(/\/search\?.*q=/, { timeout: 4000 });
+    // Focus the input then dispatch Enter keydown
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const input = sb?.shadowRoot?.querySelector('.panel-input');
+      input?.focus();
+      input?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    });
+    await navPromise;
+
+    expect(page.url()).toMatch(/\/search\?.*q=frankenstein/);
+  });
+
+  test('"See all N results" button navigates to /search?q=<query>', async ({ page }) => {
+    await openPanelAndType(page, 'frankenstein');
+
+    // Wait for autocomplete to fetch so the "See all" button appears
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('.ac-see-all') !== null;
+    }, { timeout: 5000 });
+
+    const navPromise = page.waitForURL(/\/search\?.*q=/, { timeout: 4000 });
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.ac-see-all')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+    await navPromise;
+
+    expect(page.url()).toMatch(/\/search\?.*q=frankenstein/);
+  });
+
+  test('ol-search event is cancelable — calling preventDefault() suppresses navigation', async ({ page }) => {
+    // A host that handles ol-search itself can prevent the fallback URL navigation.
+    await page.evaluate(() => {
+      document.addEventListener('ol-search', e => e.preventDefault(), { once: true });
+    });
+
+    await openPanelAndType(page, 'frankenstein');
+
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.panel .submit')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+
+    // Wait a beat — if navigation happened despite preventDefault, the URL would change.
+    await page.waitForTimeout(800);
+    expect(page.url()).not.toMatch(/\/search\?/);
   });
 });

--- a/frontend/tests/facet-and-submit.spec.js
+++ b/frontend/tests/facet-and-submit.spec.js
@@ -215,6 +215,40 @@ test.describe('droppable submit navigation (issue #44)', () => {
     expect(page.url()).toMatch(/\/search\?.*q=frankenstein/);
   });
 
+  test('active filters are included in the navigation URL', async ({ page }) => {
+    // Set an availability filter directly on the droppable ol-search-bar's local state,
+    // then submit — the resulting URL must include the availability param.
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.trigger-btn')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.shadowRoot?.querySelector('.panel-input') !== null;
+    });
+
+    // Type a query and set a filter via ol-filter-change event on the component
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      const input = sb?.shadowRoot?.querySelector('.panel-input');
+      if (input) { input.value = 'frankenstein'; input.dispatchEvent(new Event('input', { bubbles: true })); }
+      // Directly mutate _localFilters to simulate a filter selection
+      if (sb) sb._localFilters = { ...sb._localFilters, availability: 'readable' };
+    });
+
+    const navPromise = page.waitForURL(/\/search\?.*q=/, { timeout: 4000 });
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.panel .submit')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+    await navPromise;
+
+    expect(page.url()).toMatch(/q=frankenstein/);
+    expect(page.url()).toMatch(/availability=readable/);
+  });
+
   test('ol-search event is cancelable — calling preventDefault() suppresses navigation', async ({ page }) => {
     // A host that handles ol-search itself can prevent the fallback URL navigation.
     await page.evaluate(() => {

--- a/frontend/tests/mobile-overlay.spec.js
+++ b/frontend/tests/mobile-overlay.spec.js
@@ -133,6 +133,67 @@ test.describe('mobile full-screen overlay (issue #23)', () => {
   });
 });
 
+// ── Body scroll lock (issue #44) ──────────────────────────────────────────────
+//
+// Written BEFORE the documentElement scroll-lock fix so they fail red first.
+// The previous fix locked document.body but not document.documentElement;
+// many browsers/frameworks scroll <html>, so the page behind the overlay
+// remained scrollable and a full-page scrollbar appeared.
+
+test.describe('mobile overlay — body scroll lock', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+  });
+
+  test('document.body and documentElement have overflow:hidden while overlay is open', async ({ page }) => {
+    await openSearch(page);
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
+
+    const overflow = await page.evaluate(() => ({
+      body: getComputedStyle(document.body).overflow,
+      html: getComputedStyle(document.documentElement).overflow,
+    }));
+
+    expect(overflow.body).toBe('hidden');
+    expect(overflow.html).toBe('hidden');
+  });
+
+  test('body and documentElement overflow is restored after overlay closes', async ({ page }) => {
+    await openSearch(page);
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === true;
+    }, { timeout: 2000 });
+
+    // Close via back button
+    await page.evaluate(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      sb?.shadowRoot?.querySelector('.mob-back-btn')
+        ?.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
+    });
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?.classList.contains('mobile-exp') === false;
+    }, { timeout: 2000 });
+
+    const overflow = await page.evaluate(() => ({
+      body: document.body.style.overflow,
+      html: document.documentElement.style.overflow,
+    }));
+
+    expect(overflow.body).toBe('');
+    expect(overflow.html).toBe('');
+  });
+});
+
 test.describe('desktop — no overlay regression', () => {
   test('clicking search trigger on desktop does NOT add mobile-exp class', async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });

--- a/frontend/tests/mobile-overlay.spec.js
+++ b/frontend/tests/mobile-overlay.spec.js
@@ -211,3 +211,58 @@ test.describe('desktop — no overlay regression', () => {
     expect(hasMobileExp).toBe(false);
   });
 });
+
+// ── Desktop droppable — body scroll lock ─────────────────────────────────────
+//
+// Written BEFORE the fix that extended scroll locking from mobile-only to all
+// droppable modes.  These tests fail red on the old code and go green once
+// updated() gates the lock on _open && showFacets instead of _mobileExpanded.
+
+test.describe('desktop droppable — body scroll lock', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto('/');
+    await waitForSearchBar(page);
+  });
+
+  test('body and documentElement have overflow:hidden while droppable panel is open', async ({ page }) => {
+    await openSearch(page);
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?._open === true;
+    }, { timeout: 2000 });
+
+    const overflow = await page.evaluate(() => ({
+      body: getComputedStyle(document.body).overflow,
+      html: getComputedStyle(document.documentElement).overflow,
+    }));
+
+    expect(overflow.body).toBe('hidden');
+    expect(overflow.html).toBe('hidden');
+  });
+
+  test('body and documentElement overflow is restored after panel closes', async ({ page }) => {
+    await openSearch(page);
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?._open === true;
+    }, { timeout: 2000 });
+
+    await page.keyboard.press('Escape');
+
+    await page.waitForFunction(() => {
+      const sb = document.querySelector('ol-header')?.shadowRoot?.querySelector('ol-search-bar');
+      return sb?._open === false;
+    }, { timeout: 2000 });
+
+    const overflow = await page.evaluate(() => ({
+      body: document.body.style.overflow,
+      html: document.documentElement.style.overflow,
+    }));
+
+    expect(overflow.body).toBe('');
+    expect(overflow.html).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary

Two critical bugs exposed by the gap between what tests checked vs. what actually needed to work.

### Bug 1 — Submit/Enter/See-all never navigated in droppable mode

\`_submit()\` always dispatched \`ol-search\` but never navigated. The existing test only checked \`window.__olSearchFired === true\` — not that the URL changed. Nobody caught it.

**Fix:**
- Add \`_buildSearchUrl(q, filters)\` — constructs \`new URL('/search', siteBase)\` with all filter params via \`URLSearchParams\`
- Make \`ol-search\` cancelable. Hosts that handle navigation themselves can call \`e.preventDefault()\` to suppress the fallback
- \`_submit()\` and the "See all N results" button both do \`window.location.href = _buildSearchUrl(...)\` when \`showFacets=true\` and the event wasn't cancelled
- Embedded mode (\`showFacets=false\`) is unchanged — no navigation added there

### Bug 2 — Page behind overlay still scrollable

\`document.body.style.overflow = 'hidden'\` only locks \`<body>\`. Many browsers (and the demo page) actually scroll \`<html>\`. The overlay was \`position:fixed\` but the scrollbar remained visible behind it.

**Fix:** Lock both \`document.documentElement\` and \`document.body\` whenever the droppable search panel is open on **any viewport** (not only the mobile full-screen overlay). Restore both on close and in \`disconnectedCallback\`. The lock is keyed on \`changed.has('_open') && this.showFacets\` so embedded mode is unaffected.

### TDD process

Playwright tests were written **before** the fixes (failing red), proving the regression, then the fixes made them green:
- submit button → navigates to \`/search?q=<query>\`
- Enter key → navigates to \`/search?q=<query>\`
- "See all N results" → navigates to \`/search?q=<query>\`
- active filters appear in navigation URL
- \`preventDefault()\` suppresses navigation
- \`body\` + \`documentElement\` have \`overflow:hidden\` while mobile overlay is open
- both restored to \`''\` on close
- desktop droppable panel also locks scroll (new)

\`AGENTS.md\` updated with an explicit TDD section so this pattern is the default going forward.

## Test plan
- [ ] \`npx vitest run\` — 189 static-analysis tests pass
- [ ] \`npx playwright test tests/facet-and-submit.spec.js\` — all navigation tests pass
- [ ] \`npx playwright test tests/mobile-overlay.spec.js\` — scroll lock tests pass (mobile + desktop)
- [ ] Manual: type query in droppable bar, press Enter → navigates to OL search page
- [ ] Manual: click "See all N results" → navigates to OL search page
- [ ] Manual: mobile overlay open → no page scrollbar visible behind overlay
- [ ] Manual: desktop panel open → page behind panel is not scrollable